### PR TITLE
Hovered chapter title fallback near start

### DIFF
--- a/uosc.lua
+++ b/uosc.lua
@@ -1662,15 +1662,26 @@ function render_timeline(this)
 		local hovered_seconds = state.duration * (cursor.x / display.width)
 		local chapter_title = ''
 		local chapter_title_width = 0
+		local chapter_title_0 = ''
+		local chapter_title_width_0 = 0
+		local chapter_time_0 = 1
 		if (rendered_chapters and state.chapters) then
 			for i = #state.chapters, 1, -1 do
 				local chapter = state.chapters[i]
+				if chapter.time < chapter_time_0 then
+					chapter_title_0 = chapter.title_wrapped
+					chapter_title_width_0 = chapter.title_wrapped_width
+				end
 				if hovered_seconds >= chapter.time then
 					chapter_title = chapter.title_wrapped
 					chapter_title_width = chapter.title_wrapped_width
 					break
 				end
 			end
+		end
+		if chapter_title_width == 0 then
+			chapter_title = chapter_title_0
+			chapter_title_width = chapter_title_width_0
 		end
 		local time_formatted = mp.format_time(hovered_seconds)
 		local margin_time = text_width_estimate(time_formatted, this.font_size) / 2


### PR DESCRIPTION
When hovering to the left edge, displays the first chapter's title even if that chapter is tagged a few milliseconds after 00:00:00.00.  
It may be an optimization to break early if `chapter.time >= 1`, but this is such a niche case that adding a confusing condition isn't warranted.

Using extra variables and only setting the title if everything fails, the naive approach below would incorrectly always display the first chapter when there are multiple chapters within the first second.
```diff
-	if hovered_seconds >= chapter.time then
+	if hovered_seconds >= chapter.time or (hovered_seconds < 1 and chapter.time < 1) then
```
If you have a nicer approach that wouldn't require going through the chapter list twice, I will update this PR.