### PR TITLE
Initialize `playlist_count` to prevent crash

### DIFF
--- a/uosc.lua
+++ b/uosc.lua
@@ -158,6 +158,8 @@ local state = {
 	cached_ranges = nil,
 	render_delay = config.render_delay,
 	first_real_mouse_move_received = false,
+	playlist_count = 0,
+	playlist_pos = 0,
 }
 local forced_key_bindings -- defined at the bottom next to events
 


### PR DESCRIPTION
Started crashing in line 1935 after updating to the latest code.
Turns out that depending on how the timing works out when starting, `playlist_count` might still be nil when rendering.
Simply initialize `playlist_count` and `playlist_pos` to make sure that doesn't happen.