### PR TITLE
Timeline cursor pixel middle

### DIFF
--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -1728,7 +1728,8 @@ function render_timeline(this)
 
 	-- Hovered time and chapter
 	if (this.proximity_raw == 0 or this.pressed) and not (elements.speed and elements.speed.dragging) then
-		local hovered_seconds = this:get_time_at_x(cursor.x)
+		-- add 0.5 to be in the middle of the pixel
+		local hovered_seconds = this:get_time_at_x(cursor.x + 0.5)
 		local chapter_title = ''
 		local chapter_title_width = 0
 		if (options.timeline_chapters ~= 'never' and state.chapters) then
@@ -2418,7 +2419,8 @@ elements:add('timeline', Element.new({
 		return state.duration * progress
 	end,
 	set_from_cursor = function(this)
-		mp.commandv('seek', this:get_time_at_x(cursor.x), 'absolute+exact')
+		-- add 0.5 to be in the middle of the pixel
+		mp.commandv('seek', this:get_time_at_x(cursor.x + 0.5), 'absolute+exact')
 	end,
 	on_mbtn_left_down = function(this)
 		this.pressed = true


### PR DESCRIPTION
I don't know if that's a desirable change or not, but I was wondering why, when seeking to a position and having an odd number as line width, it would end up with blurry edges at the progress line. After all with an odd number there is exactly one pixel in the middle and so it should be able to cleanly display the progress line.

After ruling out faulty time calculation and rendering, it turns out the problem was that cursor x coordinate points at the left edge of the pixel, while what I visualizing was in the middle of the pixel.

Technically this also makes hovered chapters more accurate, because depending how the chapter line gets rounded, without this change it might still show the previous chapter even one pixel after the line.
Not that anyone would ever really notice that without looking reeeaaally closely.

Also this depends on #151. I'll need to rebase after the other one gets merged.