### PR TITLE
feat: don't show chapter end on hover

### DIFF
--- a/script-opts/uosc.conf
+++ b/script-opts/uosc.conf
@@ -152,6 +152,10 @@ default_directory=~/
 # They only need to occur in a title, not match it completely.
 # Matching is case insensitive.
 #
+# Chapters that end a range and got matched by an `end_pattern` other then `.*`
+# will not be shown on hover, unless that chapter is also used to start another
+# range.
+#
 # `color` is a `bbggrr` hexadecimal color code.
 # `opacity` is a float number from 0 to 1.
 #

--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -1735,8 +1735,10 @@ function render_timeline(this)
 			for i = #state.chapters, 1, -1 do
 				local chapter = state.chapters[i]
 				if hovered_seconds >= chapter.time then
-					chapter_title = chapter.title_wrapped
-					chapter_title_width = chapter.title_wrapped_width
+					if not chapter.is_end_only then
+						chapter_title = chapter.title_wrapped
+						chapter_title_width = chapter.title_wrapped_width
+					end
 					break
 				end
 			end
@@ -2849,6 +2851,7 @@ for _, definition in ipairs(split(options.chapter_ranges, ' *,+ *')) do
 				-- If there is already a range started, should we append or overwrite?
 				-- I chose overwrite here.
 				current_range = {['start'] = chapter}
+				chapter.is_end_only = false
 			end
 
 			local function end_range(chapter)
@@ -2869,8 +2872,12 @@ for _, definition in ipairs(split(options.chapter_ranges, ' *,+ *')) do
 
 					-- Is ending check and handling
 					if chapter_range.end_patterns then
+						chapter.is_end_only = false
 						for _, end_pattern in ipairs(chapter_range.end_patterns) do
-							is_end = is_end or lowercase_title:find(end_pattern) ~= nil
+							if lowercase_title:find(end_pattern) then
+								is_end = true
+								chapter.is_end_only = chapter.is_end_only or end_pattern ~= '.*'
+							end
 						end
 
 						if is_end then


### PR DESCRIPTION
Chapters that end a chapter range and are matched by something other
then `.*` are now not shown when hovering over that chapter.

Closes #125