### PR TITLE
fix: compatiblity with `unpack` and `table.unpack`

### DIFF
--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -3588,7 +3588,7 @@ mp.register_script_message('show-menu', function(json)
 		if type(value) == 'string' then
 			mp.command(value)
 		else
-			mp.commandv(table.unpack(value))
+			mp.commandv((unpack or table.unpack)(value))
 		end
 	end
 


### PR DESCRIPTION
In Lua 5.2 the unpack global has been moved to table.unpack
To keep compatiblity with 5.1 and newer, choose depending on what's
available.