### PR TITLE
fix: add border to title in top bar again

### DIFF
--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -1850,6 +1850,7 @@ function render_top_bar(this)
 		ass:txt(this.ax + this.spacing, this.ay + (this.size / 2), 4, text, {
 			size = this.font_size, wrap = 2, color = 'FFFFFF', border_color = '000000',
 			clip = '\\clip(' .. clip_coordinates .. ')',
+			border = 1,
 		})
 	end
 


### PR DESCRIPTION
The border got lost in 39ae0650c1eb3cad75043d71eeac2f0c4a46185d.

Closes #158