### PR TITLE
fix: cap volume to >=0

### DIFF
--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -2561,11 +2561,14 @@ if itable_find({'left', 'right'}, options.volume) then
 			this.draw_nudge = this.ay < this.nudge_y
 			this.spacing = round(this.width * 0.2)
 		end,
+		set_volume = function(this, volume)
+			volume = round(volume / options.volume_step) * options.volume_step
+			if state.volume == volume then return end
+			mp.commandv('set', 'volume', math.max(math.min(volume, state.volume_max), 0))
+		end,
 		set_from_cursor = function(this)
 			local volume_fraction = (this.by - cursor.y - options.volume_border) / (this.height - options.volume_border)
-			local new_volume = math.min(math.max(volume_fraction, 0), 1) * state.volume_max
-			new_volume = round(new_volume / options.volume_step) * options.volume_step
-			if state.volume ~= new_volume then mp.commandv('set', 'volume', math.min(new_volume, state.volume_max)) end
+			this:set_volume(volume_fraction * state.volume_max)
 		end,
 		on_prop_has_audio = function(this, has_audio) this.enabled = has_audio end,
 		on_mbtn_left_down = function(this)
@@ -2577,14 +2580,8 @@ if itable_find({'left', 'right'}, options.volume) then
 		on_global_mouse_move = function(this)
 			if this.pressed then this:set_from_cursor() end
 		end,
-		on_wheel_up = function(this)
-			local current_rounded_volume = round(state.volume / options.volume_step) * options.volume_step
-			mp.commandv('set', 'volume', math.min(current_rounded_volume + options.volume_step, state.volume_max))
-		end,
-		on_wheel_down = function(this)
-			local current_rounded_volume = round(state.volume / options.volume_step) * options.volume_step
-			mp.commandv('set', 'volume', math.min(current_rounded_volume - options.volume_step, state.volume_max))
-		end,
+		on_wheel_up = function(this) this:set_volume(state.volume + options.volume_step) end,
+		on_wheel_down = function(this) this:set_volume(state.volume - options.volume_step) end,
 	}))
 end
 if itable_find({'center', 'bottom-bar'}, options.menu_button) then
@@ -2674,12 +2671,6 @@ if options.speed then
 			this.ay = this.by - this.height
 			this.bx = this.ax + this.width
 			this.font_size = round(this.height * 0.48 * options.speed_font_scale)
-		end,
-		set_from_cursor = function(this)
-			local volume_fraction = (this.by - cursor.y - options.volume_border) / (this.height - options.volume_border)
-			local new_volume = math.min(math.max(volume_fraction, 0), 1) * state.volume_max
-			new_volume = round(new_volume / options.volume_step) * options.volume_step
-			if state.volume ~= new_volume then mp.commandv('set', 'volume', new_volume) end
 		end,
 		on_prop_time = function(this, time) this.enabled = time ~= nil end,
 		on_prop_border = function(this) this:update_dimensions() end,


### PR DESCRIPTION
With a step size of 1 it was possible to set volume to -1.
mpv permits setting volume to -1 for legacy reasons, so cap it in the ui.

There was a `set_from_cursor` method for setting volume in the speed element.
Probably got copied there at some point by accident.

Closes #157