### PR TITLE
feat: better default config for chapter ranges

### DIFF
--- a/script-opts/uosc.conf
+++ b/script-opts/uosc.conf
@@ -170,4 +170,4 @@ default_directory=~/
 # ```
 # chapter_ranges=sponsor start<3535a5:.5>sponsor end, segment start<3535a5:0.5>segment end
 # ```
-chapter_ranges=^op| op$|opening<968638:0.5>.*, ^ed| ed$|^end|ending$<968638:0.5>.*|{eof}, sponsor start<3535a5:.5>sponsor end, segment start<3535a5:0.5>segment end
+chapter_ranges=^op |^op$| op$|opening$<968638:0.5>.*, ^ed |^ed$| ed$|ending$<968638:0.5>.*|{eof}, sponsor start<3535a5:.5>sponsor end, segment start<3535a5:0.5>segment end, ^sponsors?<3535a5:.5>.*, ^intro$<968638:0.5>.*, ^outro$<968638:0.5>.*|{eof}


### PR DESCRIPTION
I have recently noticed that a lot of videos have "Intro" and "Outro" chapters, Should we match on those as well?