### PR TITLE
fix: pixel to time calculation

### DIFF
--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -2629,9 +2629,11 @@ function Timeline:update_dimensions()
 end
 
 function Timeline:get_time_at_x(x)
-	-- padding serves the purpose of matching cursor to timeline_style=line exactly
-	local padding = (options.timeline_style == 'line' and self:get_effective_line_width() or 0) / 2
-	local progress = math.max(0, math.min((x - self.ax - padding) / (self.width - padding * 2), 1))
+	-- line width 1 for timeline_style=bar so mouse input can go all the way from 0 to 1 progress
+	local line_width = (options.timeline_style == 'line' and self:get_effective_line_width() or 1)
+	local time_width = self.width - line_width
+	local progress_x = x - self.ax - line_width / 2
+	local progress = math.max(0, math.min(progress_x / time_width, 1))
 	return state.duration * progress
 end
 
@@ -2693,8 +2695,8 @@ function Timeline:render()
 			and width_normal - width_normal * options.timeline_line_width_minimized_scale
 			or 0
 		local line_width = width_normal - (max_min_width_delta * minimized_fraction)
-		local current_time_x = (bbx - bax - line_width) * progress
-		fax = current_time_x + bax
+		local time_width = self.width - line_width
+		fax = bax + time_width * progress
 		fbx = fax + line_width
 		if line_width > 2 then time_padding = round(line_width / 2) end
 	else


### PR DESCRIPTION
While things were sort of fine with `timeline_style=line`,
it was impossible to set the time to 0% or 100% when using
`timeline_style=bar`.

Now the time calculation is correct regardless of style and the
rendering is pixel perfect.

However I'm not entirely sure about the way the `timeline_style=bar` gets rendered now. It is technically correct in the sense that mouse input can go from 0% to 100% and the bar always gets displayed perfectly to the interpolated point between those two mouse input positions, so when seeking the result always lines up perfectly with the mouse input.

But that also means that when seeking to 0% the timeline bar isn't completely empty anymore, and when seeking to 100% it is also not completely full. Instead it always draws half a pixel at the edge.

Alternatively we could:
1. set the line width in the rendering part to 0, resulting in the same rendering as it used to be (empty bar at 0% and completely full at 100%)
2. not add the `line_width / 2` to `fbx`, resulting in an empty bar at 0%, but with the last pixel not drawn at all at 100%
3. add `line_width` instead of `line_width / 2` to `fbx`, resulting in the first pixel being fully drawn at 0%, and the last pixel being fully drawn at 100%

2 and 3 result in a clean edge when seeking with the mouse, while 1 basically has the pixel at the edge interpolated over the whole width (e.g. being half drawn at 50% time).

Let me know which one you prefer.