### PR TITLE
Real time width

### DIFF
--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -2769,14 +2769,14 @@ function Timeline:render()
 			local function draw_chapter(time)
 				local chapter_x = time_x + time_width * (time / state.duration)
 				local ax, bx = chapter_x - chapter_half_width, chapter_x + chapter_half_width
-				local cx, dx = math.max(ax, fax), math.min(bx, fbx)
 				local opts = {
 					color = options.color_foreground,
 					clip = dots and '\\iclip(' .. foreground_coordinates .. ')' or nil,
 					opacity = options.timeline_chapters_opacity,
 				}
-
+				
 				if dots then
+					local cx, dx = math.max(ax, fax), math.min(bx, fbx)
 					-- 0.5 because clipping coordinates are rounded
 					if (ax - 0.5) < fax or (bx + 0.5) > fbx then
 						ass:circle(chapter_x, chapter_y, chapter_half_height, opts)
@@ -2788,6 +2788,7 @@ function Timeline:render()
 					end
 				else
 					ax, bx = round(ax), round(bx)
+					local cx, dx = math.max(ax, fax), math.min(bx, fbx)
 					local ay, by = chapter_y - chapter_half_height, chapter_y + chapter_half_height
 					if ax < fax then --left of progress
 						ass:rect(ax, ay, math.min(bx, fax), by, opts)


### PR DESCRIPTION
This started off with noticing that a chapter line at time 0, that is supposed to be 1 pixel wide, was rendered over two pixels.

After the first commit it was a single line, but it was one pixel too far to the right. Turns out the culprit was the `time_x` and `time_width` calculation, which in turn is also connected to the cache.

The cache border indicator now doesn't overlap with the beginning and the end of the cache anymore and it always shows when there is at least a pixel between the cache start and the timeline start. That means it is always visible for progress lines with a width of 2 or more (only when there is a cache, ofc). I think it is more correct that way, but it differs from the previous behavior.

Commit messages contain some additional info.

This has a merge conflict with #174, but it's an easy fix.