### PR TITLE
fix: `is_protocol()` not returning a boolean

### DIFF
--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -529,7 +529,7 @@ end
 
 -- Check if path is a protocol, such as `http://...`
 function is_protocol(path)
-	return type(path) == 'string' and path:match('^%a[%a%d-_]+://')
+	return type(path) == 'string' and path:match('^%a[%a%d-_]+://') ~= nil
 end
 
 function get_extension(path)


### PR DESCRIPTION
The stream-quality control was never shown, because `is_stream` gets compared to a boolean, but `is_protocol` returned a string and so it always got filtered out.