### PR TITLE
fix: menu `hint_width` calculated from title

### DIFF
--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -1589,7 +1589,7 @@ end
 function Menu:update(data)
 	self.type = data.type
 
-	local new_root = {is_root = true}
+	local new_root = {is_root = true, title_length = text_length(data.title), hint_length = text_length(data.hint)}
 	local new_all = {}
 	local new_by_id = {}
 	local menus_to_serialize = {{new_root, data}}
@@ -1606,8 +1606,6 @@ function Menu:update(data)
 			menu.id = (parent_id and parent_id .. ' > ' or '') .. (menu_data.title or i)
 		end
 		menu.icon = 'chevron_right'
-		menu.title_length = text_length(menu.title)
-		menu.hint_length = text_length(menu.title)
 
 		-- Update items
 		local first_active_index = nil


### PR DESCRIPTION
The hint length was calculated with the menu title, that led to wrong menu widths.
before
![menu_master](https://user-images.githubusercontent.com/8932183/190028388-fc5ccd31-1ff4-4b50-bcf6-391724c8052b.png)
after
![menu_patched](https://user-images.githubusercontent.com/8932183/190029281-4502e631-4738-469c-af56-1169cac11b16.png)
Also any submenus already have their lengths set from a previous iteration, so moving it out of the loop to the root directly.