### PR TITLE
fix: chapter ranges

### DIFF
--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -373,6 +373,7 @@ local state = {
 	duration_or_remaining_time_human = nil, -- depends on options.total_time
 	pause = mp.get_property_native('pause'),
 	chapters = nil,
+	chapter_ranges = nil,
 	border = mp.get_property_native('border'),
 	fullscreen = mp.get_property_native('fullscreen'),
 	maximized = mp.get_property_native('window-maximized'),
@@ -403,7 +404,6 @@ local state = {
 }
 
 -- Parse `chapter_ranges` option into workable data structure
-local chapter_ranges = nil
 for _, definition in ipairs(split(options.chapter_ranges, ' *,+ *')) do
 	local start_patterns, color, opacity, end_patterns = string.match(
 		definition, '([^<]+)<(%x%x%x%x%x%x):(%d?%.?%d*)>([^>]+)'
@@ -493,8 +493,8 @@ for _, definition in ipairs(split(options.chapter_ranges, ' *,+ *')) do
 			end
 		end
 
-		chapter_ranges = chapter_ranges or {}
-		chapter_ranges[#chapter_ranges + 1] = chapter_range
+		state.chapter_ranges = state.chapter_ranges or {}
+		state.chapter_ranges[#state.chapter_ranges + 1] = chapter_range
 	end
 end
 


### PR DESCRIPTION
I can't tell what the plan was here, but rendering and calling serialization still referenced `state.chapter_ranges`, so I simply moved it back into the state to restore the functionality.

Edit: If you want to move it out of the state, might I suggest moving it into the timeline? Because that's the only element that cares about them.