### PR TITLE
feat: add multiple subtitles as filters in menu

### DIFF
--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -4025,7 +4025,7 @@ function open_file_navigation_menu(directory_path, handle_select, opts)
 		if path.is_directory then
 			--  Preselect directory we are coming from
 			if path.is_to_parent then
-				inheritable_options.selected_path = directory.path
+                inheritable_options.active_path = directory.path
 			end
 
 			open_file_navigation_menu(path.path, handle_select, inheritable_options)

--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -1877,6 +1877,13 @@ end
 
 function Menu:back()
 	local menu = self.current
+
+    local item = menu.items[1]
+    if item.hint and item.hint == 'parent dir' then
+        self.callback(item.value)
+        return
+    end
+
 	local parent = menu.parent_menu
 
 	if not parent then return self:close() end

--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -4312,14 +4312,17 @@ mp.add_key_binding(nil, 'chapters', create_self_updating_menu_opener({
 				value = chapter.time,
 			}
 			items[#items + 1] = item
-			if active_found == false then
-				local is_active = chapter.time >= state.time
-				if is_active then
-					item.active = true
-					active_found = true
-				end
-			end
 		end
+        for index = #items, 1, -1 do
+            if state.time >= items[index].value then
+                items[index].active = true
+                active_found = true
+                break
+            end
+        end
+        if active_found == false and #items > 0 then
+            items[1].active = true
+        end
 		return items
 	end,
 	active_prop = 'playback-time',

--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -4588,3 +4588,126 @@ mp.register_script_message('update-menu', function(json)
 		else open_command_menu(data) end
 	end
 end)
+
+local multi_subtitles_info = {}
+
+function multi_subtitles_clear()
+    for index, value in ipairs(multi_subtitles_info) do
+        mp.command(value.remove)
+
+    multi_subtitles_info = {}
+    end
+end
+
+function multi_subtitles_exist(id)
+    for index, value in ipairs(multi_subtitles_info) do
+        if value.id == id then
+            return true, index
+        end
+    end
+
+    return false, -1
+end
+
+function multi_subtitles_update(id, vf2)
+    local exist, index = multi_subtitles_exist(id)
+    if exist then
+        table.remove(multi_subtitles_info, index)
+    else
+        multi_subtitles_info[#multi_subtitles_info + 1] = {
+            id = id,
+            remove = 'vf remove' .. vf2
+        }
+    end
+end
+
+function multi_subtitles_toggle(id)
+    if id == 0 then
+        multi_subtitles_clear()
+    else
+        for index, track in ipairs(mp.get_property_native('track-list')) do
+            local exist, index = multi_subtitles_exist(id)
+            local vf1 = ''
+            if exist then
+                vf1 = 'remove'
+            else
+                vf1 = 'append'
+            end
+            if track.type == 'sub' and track.id == id then
+                if not track.external then
+                    local path = mp.get_property_native('path')
+                    local vf2 = ' ``subtitles=filename=\"' .. path .. '\":stream_index=' .. id - 1 .. '``'
+                    local vf = 'vf ' .. vf1 .. vf2
+                    mp.command(vf)
+
+                    multi_subtitles_update(id, vf2)
+                else
+                    local path = track['external-filename']
+                    local vf2 = ' ``subtitles=filename=\"' .. path .. '\"``'
+                    local vf = 'vf '.. vf1 .. vf2
+                    mp.command(vf)
+
+                    multi_subtitles_update(id, vf2)
+                end
+            end
+        end
+    end
+end
+
+function multi_subtitles_recovery()
+    local info = multi_subtitles_info
+    multi_subtitles_clear()
+    for index, value in ipairs(info) do
+        multi_subtitles_toggle(value.id)
+    end
+end
+
+function create_multi_subtitles_menu_opener()
+    return function()
+		if Menu:is_open('sub') then Menu:close() return end
+
+        local items = {}
+        items[#items + 1] = {title = 'Clear', italic = true, muted = true, value = 0}
+        for index, track in ipairs(mp.get_property_native('track-list')) do
+            if track.type == 'sub' then
+                items[#items + 1] = {
+                    title = (track.title and track.title or 'Track '..track.id),
+                    hint = track.lang and track.lang:upper() or nil,
+                    value = track.id,
+                    external = track.external,
+                    external_path = track['external-filename']
+                }
+            end
+        end
+
+        Menu:open({type = 'sub', title = 'Multi-Subtitles', items = items}, function(id)
+            multi_subtitles_toggle(id)
+        end, {})
+    end
+end
+mp.add_key_binding(nil, 'multi-subtitles', create_multi_subtitles_menu_opener())
+
+local clock = os.clock
+function sleep(n)
+    local t0 = clock()
+    while clock() - t0 <= n do end
+end
+
+mp.add_key_binding(nil, 'playlist-next-keep-multi-subtitles-status', function()
+    if state.has_playlist then
+        mp.command('playlist-next')
+    else
+        navigate_directory('forward')
+    end
+    sleep(0.5)
+    multi_subtitles_recovery()
+end)
+mp.add_key_binding(nil, 'playlist-prev-keep-multi-subtitles-status', function()
+    if state.has_playlist then
+        mp.command('playlist-prev')
+    else
+        navigate_directory('backward')
+    end
+    sleep(0.5)
+    multi_subtitles_recovery()
+end)


### PR DESCRIPTION
feat: back to parent dir when in uosc/open-file menu
fix: preselect correctly when back to the parent dir
fix: correct the chapter index in the chapter menu
feat:
multi-subtitles: select from current directory or mkv built-in subtitles and load them as filters
playlist-prev-keep-multi-subtitles-status: select the previous episode and update the subtitles of the corresponding video
playlist-next-keep-multi-subtitles-status: select the next episode and update the subtitles of the corresponding video
