### PR TITLE
fix: render on cache update

### DIFF
--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -4209,6 +4209,7 @@ mp.observe_property('demuxer-cache-state', 'native', function(prop, cache_state)
 		end
 	end
 	set_state('uncached_ranges', uncached_ranges)
+	request_render()
 end)
 mp.observe_property('display-fps', 'native', observe_display_fps)
 mp.observe_property('estimated-display-fps', 'native', update_render_delay)


### PR DESCRIPTION
I feel like we've been here before *caugh*#89*caugh*

Actually trigger already calls `request_render()`, so this should be entirely unneeded, but then how come I sometimes have videos that are fully cached but still show like half the video uncached until I interact with it.... Don't even know how I should debug this with how unreliable that happens.