### PR TITLE
fix: thumbnail decoration with scaling

### DIFF
--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -2912,8 +2912,8 @@ function Timeline:render()
 				display.width * scale - thumbnail.width - thumb_x_margin
 			))
 			local thumb_y = round(tooltip_anchor.ay * scale - thumb_y_margin - thumbnail.height)
-			local ax, ay = thumb_x - border, thumb_y - border
-			local bx, by = thumb_x + border + thumbnail.width, thumb_y + border + thumbnail.height
+			local ax, ay = (thumb_x - border) / scale, (thumb_y - border) / scale
+			local bx, by = (thumb_x + border + thumbnail.width) / scale, (thumb_y + border + thumbnail.height) / scale
 			ass:rect(ax, ay, bx, by, {
 				color = options.foreground, border = 1, border_color = options.background, radius = 3, opacity = 0.6,
 			})


### PR DESCRIPTION
Fixes the scaling as noted in https://github.com/tomasklaen/uosc/pull/213#issuecomment-1253839467

Screenshot is with 1.6 scaling factor.

![timeline_thumbnail_scaling](https://user-images.githubusercontent.com/8932183/191588874-83204663-0602-448a-8624-ccdf096a2c17.png)
