### PR TITLE
fix: border in thumbnail decoration calculation was already scaled

### DIFF
--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -2925,8 +2925,8 @@ function Timeline:render()
 				display.width * scale - thumbnail.width - thumb_x_margin
 			))
 			local thumb_y = round(tooltip_anchor.ay * scale - thumb_y_margin - thumbnail.height)
-			local ax, ay = (thumb_x - border) / scale, (thumb_y - border) / scale
-			local bx, by = (thumb_x + border + thumbnail.width) / scale, (thumb_y + border + thumbnail.height) / scale
+			local ax, ay = thumb_x / scale - border, thumb_y / scale - border
+			local bx, by = (thumb_x + thumbnail.width) / scale + border, (thumb_y + thumbnail.height) / scale + border
 			ass:rect(ax, ay, bx, by, {
 				color = options.foreground, border = 1, border_color = options.background, radius = 3, opacity = 0.8,
 			})


### PR DESCRIPTION
There was a problem in #238 where in the `ax`, `ay`, `bx`, `by` calculations the border size was scaled despite already being a scaled size. Depending on the scale factor, this can make a noticeable difference.

This unfortunately does not fix https://github.com/tomasklaen/uosc/pull/238#issuecomment-1255101569.