### PR TITLE
fix: time can be nil when creating chapter menu

### DIFF
--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -4390,6 +4390,7 @@ mp.add_key_binding(nil, 'chapters', create_self_updating_menu_opener({
 			}
 			items[#items + 1] = item
 		end
+		if not state.time then return items end
 		for index = #items, 1, -1 do
 			if state.time >= items[index].value then
 				items[index].active = true


### PR DESCRIPTION
When opening the chapter menu right after opening mpv with a YouTube video that has chapters, but before the video actually loaded, it would end up in a nil error.
![nil_chapter_menu](https://user-images.githubusercontent.com/8932183/191841530-1e2f7f4a-f610-400d-b267-f663516ed16b.png)
