### PR TITLE
feat: set uncached ranges as early as possible

### DIFF
--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -4240,9 +4240,13 @@ mp.observe_property('osd-dimensions', 'native', function(name, val)
 end)
 mp.observe_property('display-hidpi-scale', 'native', create_state_setter('hidpi_scale', update_display_dimensions))
 mp.observe_property('demuxer-via-network', 'native', create_state_setter('is_stream', function()
-	set_state('uncached_ranges', state.is_stream and state.duration and {0, state.duration} or nil)
 	Elements:trigger('dispositions')
 end))
+mp.observe_property('cache-buffering-state', 'native', function(_, buffering_state)
+	if buffering_state and buffering_state == 0 and not state.uncached_ranges and state.duration then
+		set_state('uncached_ranges', {{0, state.duration}})
+	end
+end)
 mp.observe_property('demuxer-cache-state', 'native', function(prop, cache_state)
 	local cached_ranges = cache_state and cache_state['seekable-ranges'] or {}
 	local uncached_ranges = nil


### PR DESCRIPTION
In my testing the `cache-buffering-state` always starts off with nil, then 100 and then when it's a local file or a network one that loads quickly enough that it practically immediately has cached ranges there are no updates except when seeking for local files, where it will go down to 95 for me and then 100 again.
For files that need a bit longer to get cached ranges, it starts off with nil, then 100, and then 0. So take that 0 and use it as the cue that cached ranges are coming.

Also it turns out setting it in the `demuxer-via-network` observer didn't actually work because duration wasn't set yet and I just didn't notice because it got set in the `demuxer-cache-state` observer immediately after. But with recent changes that wasn't the case anymore and now I noticed.

Hopefully it won't lead to any false positives. If anyone knows of a better way of detecting caching early, please do tell.