### PR TITLE
fix: ensure cache ranges extend to 0 and duration

### DIFF
--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -4324,6 +4324,8 @@ mp.observe_property('demuxer-cache-state', 'native', function(prop, cache_state)
 		}
 	end
 	table.sort(ranges, function(a, b) return a[1] < b[1] end)
+	if cache_state['bof-cached'] then ranges[1][1] = 0 end
+	if cache_state['eof-cached'] then ranges[#ranges][2] = state.duration end
 	-- Invert cached ranges into uncached ranges, as that's what we're rendering
 	local inverted_ranges = {{0, state.duration}}
 	for _, cached in pairs(ranges) do


### PR DESCRIPTION
I've encountered a file that reported a duration that was 1.2 seconds longer then the end of the seekable-range, which would then show as uncached (it was also only playable until the end of the seekable-range). With the `demuxer-cache-state` reporting when the bof and the eof are cached, we can use that information to extend the first and the last cached range to then not show anything if it is fully cached.