### PR TITLE
fix: ads end could be recognized as single chapter ad

### DIFF
--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -906,7 +906,8 @@ function serialize_chapter_ranges(normalized_chapters)
 						break
 					end
 				end -- single chapter for ad
-			elseif chapter.lowercase_title:find('%[sponsorblock%]:') or chapter.lowercase_title:find('^sponsors?') then
+			elseif not chapter.is_end_only and
+				(chapter.lowercase_title:find('%[sponsorblock%]:') or chapter.lowercase_title:find('^sponsors?')) then
 				local next_chapter = chapters[i + 1]
 				ranges[#ranges + 1] = table_assign({
 					start = chapter.time,


### PR DESCRIPTION
Something like `sponsor segment end` would in the next iteration be recognized as the start of a single chapter ad range.