### PR TITLE
fix: render when thumbnail size changes

### DIFF
--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -4709,5 +4709,6 @@ mp.register_script_message('thumbfast-info', function(json)
 		msg.error('thumbfast-info: received json didn\'t produce a table with thumbnail information')
 	else
 		thumbnail = data
+		request_render()
 	end
 end)


### PR DESCRIPTION
With recent discoveries in https://github.com/po5/thumbfast/pull/31 this is necessary because the thumbnail size may change at any time, but it seems like a good thing to do in general.