### PR TITLE
feat: make `*_persistency` support idle

### DIFF
--- a/script-opts/uosc.conf
+++ b/script-opts/uosc.conf
@@ -14,7 +14,7 @@ timeline_size_min_fullscreen=0
 timeline_size_max_fullscreen=60
 # Same thing as calling toggle-progress command once on startup
 timeline_start_hidden=no
-# Comma separated states when timeline should always be visible. available: paused, audio, image, video
+# Comma separated states when timeline should always be visible. available: paused, audio, image, video, idle
 timeline_persistency=paused
 # Timeline opacity
 timeline_opacity=0.9

--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -1466,6 +1466,7 @@ function Element:get_visibility()
 			or (persist.paused and state.pause)
 			or (persist.video and state.is_video)
 			or (persist.image and state.is_image)
+			or (persist.idle and state.is_idle)
 		) then return 1 end
 
 	-- Forced visibility


### PR DESCRIPTION
Actually I think making those default value be `idle,paused` would be more reasonable for we do not had the logo/msg showing in idle. But I want to hear more opinions.