### PR TITLE
feat: add idle logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,6 +541,14 @@ This property can now be used as a control button badge by prefixing it with `@`
 controls=command:icon_name:command_name#@foo?My foo button
 ```
 
+### `osc-idlescreen <mode> <no_osd>`
+
+Controls the visibility of the mpv logo on idle.
+
+Valid arguments for ``mode`` are ``yes``, ``no``, and ``cycle`` to toggle between yes and no.
+
+Depending on the value of ``no_osd`` an osd message can be shown.
+
 ## Why _uosc_?
 
 It stood for micro osc as it used to render just a couple rectangles before it grew to what it is today. And now it means a minimalist UI design direction where everything is out of your way until needed.

--- a/script-opts/uosc.conf
+++ b/script-opts/uosc.conf
@@ -179,6 +179,10 @@ subtitle_types=aqt,ass,gsub,idx,jss,lrc,mks,pgs,pjs,psb,rt,slt,smi,sub,sup,srt,s
 font_height_to_letter_width_ratio=0.5
 # Default open-file menu directory
 default_directory=~/
+# Show the mpv logo and message when idle
+idlescreen=yes
+# Disable santa hat on idle logo in december
+greenandgrumpy=no
 
 # Convers some common chapter types into chapter range indicators.
 # Instead of displaying the start of the chapter as a diamond icon on top of the

--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -225,6 +225,8 @@ local defaults = {
 	subtitle_types = 'aqt,ass,gsub,idx,jss,lrc,mks,pgs,pjs,psb,rt,slt,smi,sub,sup,srt,ssa,ssf,ttxt,txt,usf,vt,vtt',
 	font_height_to_letter_width_ratio = 0.5,
 	default_directory = '~/',
+	idlescreen = true,
+	greenandgrumpy = false,
 	chapter_ranges = 'openings:30abf964,endings:30abf964,ads:c54e4e80',
 	chapter_range_patterns = 'openings:オープニング;endings:エンディング',
 }
@@ -441,6 +443,8 @@ local state = {
 	margin_top = 0,
 	margin_bottom = 0,
 	hidpi_scale = 1,
+	idlescreen = options.idlescreen,
+	is_december = os.date('*t').month == 12,
 }
 local thumbnail = {width = 0, height = 0, disabled = false}
 
@@ -2613,6 +2617,76 @@ function WindowBorder:render()
 	end
 end
 
+--[[ Logo ]]
+
+---@class Logo : Element
+local Logo = class(Element)
+
+function Logo:new() return Class.new(self) --[[@as Logo]] end
+function Logo:init()
+	Element.init(self, 'logo')
+	self.enabled = state.is_idle
+
+	self.logo_lines = {
+		-- White border
+		'{\\c&HE5E5E5&\\p5}m 895 10 b 401 10 0 410 0 905 0 1399 401 1800 895 1800 1390 1800 1790 1399 1790 905 1790 410 1390 10 895 10 {\\p0}',
+		-- Purple fill
+		'{\\c&H682167&\\p5}m 925 42 b 463 42 87 418 87 880 87 1343 463 1718 925 1718 1388 1718 1763 1343 1763 880 1763 418 1388 42 925 42{\\p0}',
+		-- Darker fill
+		'{\\c&H430142&\\p5}m 1605 828 b 1605 1175 1324 1456 977 1456 631 1456 349 1175 349 828 349 482 631 200 977 200 1324 200 1605 482 1605 828{\\p0}',
+		-- White fill
+		'{\\c&HDDDBDD&\\p5}m 1296 910 b 1296 1131 1117 1310 897 1310 676 1310 497 1131 497 910 497 689 676 511 897 511 1117 511 1296 689 1296 910{\\p0}',
+		-- Triangle
+		'{\\c&H691F69&\\p5}m 762 1113 l 762 708 b 881 776 1000 843 1119 911 1000 978 881 1046 762 1113{\\p0}',
+	}
+
+	self.santa_hat_lines = {
+		-- Pompoms
+		'{\\c&HC0C0C0&\\p5}m 500 -323 b 491 -322 481 -318 475 -311 465 -312 456 -319 446 -318 434 -314 427 -304 417 -297 410 -290 404 -282 395 -278 390 -274 387 -267 381 -265 377 -261 379 -254 384 -253 397 -244 409 -232 425 -228 437 -228 446 -218 457 -217 462 -216 466 -213 468 -209 471 -205 477 -203 482 -206 491 -211 499 -217 508 -222 532 -235 556 -249 576 -267 584 -272 584 -284 578 -290 569 -305 550 -312 533 -309 523 -310 515 -316 507 -321 505 -323 503 -323 500 -323{\\p0}',
+		'{\\c&HE0E0E0&\\p5}m 315 -260 b 286 -258 259 -240 246 -215 235 -210 222 -215 211 -211 204 -188 177 -176 172 -151 170 -139 163 -128 154 -121 143 -103 141 -81 143 -60 139 -46 125 -34 129 -17 132 -1 134 16 142 30 145 56 161 80 181 96 196 114 210 133 231 144 266 153 303 138 328 115 373 79 401 28 423 -24 446 -73 465 -123 483 -174 487 -199 467 -225 442 -227 421 -232 402 -242 384 -254 364 -259 342 -250 322 -260 320 -260 317 -261 315 -260{\\p0}',
+		-- Main cap
+		'{\\c&H0000F0&\\p5}m 1151 -523 b 1016 -516 891 -458 769 -406 693 -369 624 -319 561 -262 526 -252 465 -235 479 -187 502 -147 551 -135 588 -111 1115 165 1379 232 1909 761 1926 800 1952 834 1987 858 2020 883 2053 912 2065 952 2088 1000 2146 962 2139 919 2162 836 2156 747 2143 662 2131 615 2116 567 2122 517 2120 410 2090 306 2089 199 2092 147 2071 99 2034 64 1987 5 1928 -41 1869 -86 1777 -157 1712 -256 1629 -337 1578 -389 1521 -436 1461 -476 1407 -509 1343 -507 1284 -515 1240 -519 1195 -521 1151 -523{\\p0}',
+		-- Cap shadow
+		'{\\c&H0000AA&\\p5}m 1657 248 b 1658 254 1659 261 1660 267 1669 276 1680 284 1689 293 1695 302 1700 311 1707 320 1716 325 1726 330 1735 335 1744 347 1752 360 1761 371 1753 352 1754 331 1753 311 1751 237 1751 163 1751 90 1752 64 1752 37 1767 14 1778 -3 1785 -24 1786 -45 1786 -60 1786 -77 1774 -87 1760 -96 1750 -78 1751 -65 1748 -37 1750 -8 1750 20 1734 78 1715 134 1699 192 1694 211 1689 231 1676 246 1671 251 1661 255 1657 248 m 1909 541 b 1914 542 1922 549 1917 539 1919 520 1921 502 1919 483 1918 458 1917 433 1915 407 1930 373 1942 338 1947 301 1952 270 1954 238 1951 207 1946 214 1947 229 1945 239 1939 278 1936 318 1924 356 1923 362 1913 382 1912 364 1906 301 1904 237 1891 175 1887 150 1892 126 1892 101 1892 68 1893 35 1888 2 1884 -9 1871 -20 1859 -14 1851 -6 1854 9 1854 20 1855 58 1864 95 1873 132 1883 179 1894 225 1899 273 1908 362 1910 451 1909 541{\\p0}',
+		-- Brim and tip pompom
+		'{\\c&HF8F8F8&\\p5}m 626 -191 b 565 -155 486 -196 428 -151 387 -115 327 -101 304 -47 273 2 267 59 249 113 219 157 217 213 215 265 217 309 260 302 285 283 373 264 465 264 555 257 608 252 655 292 709 287 759 294 816 276 863 298 903 340 972 324 1012 367 1061 394 1125 382 1167 424 1213 462 1268 482 1322 506 1385 546 1427 610 1479 662 1510 690 1534 725 1566 752 1611 796 1664 830 1703 880 1740 918 1747 986 1805 1005 1863 991 1897 932 1916 880 1914 823 1945 777 1961 725 1979 673 1957 622 1938 575 1912 534 1862 515 1836 473 1790 417 1755 351 1697 305 1658 266 1633 216 1593 176 1574 138 1539 116 1497 110 1448 101 1402 77 1371 37 1346 -16 1295 15 1254 6 1211 -27 1170 -62 1121 -86 1072 -104 1027 -128 976 -133 914 -130 851 -137 794 -162 740 -181 679 -168 626 -191 m 2051 917 b 1971 932 1929 1017 1919 1091 1912 1149 1923 1214 1970 1254 2000 1279 2027 1314 2066 1325 2139 1338 2212 1295 2254 1238 2281 1203 2287 1158 2282 1116 2292 1061 2273 1006 2229 970 2206 941 2167 938 2138 918{\\p0}',
+	}
+end
+
+function Logo:decide_enabled() self.enabled = state.idlescreen and state.is_idle end
+function Logo:on_prop_is_idle() self:decide_enabled() end
+function Logo:on_prop_idlescreen() self:decide_enabled() end
+
+function Logo:render()
+	if Menu:is_open() then return end
+
+	local ass = assdraw.ass_new()
+
+	-- logo is rendered at 2^(5-1) = 16 times resolution with size 1800x1800
+	local logo_size, font_size, spacing = 1800 / 16, 40, 10
+	local total_height = logo_size + font_size + spacing
+	local icon_x, icon_y = (display.width - logo_size) / 2, (display.height - total_height) / 2
+	local line_prefix = ('{\\rDefault\\an7\\1a&H00&\\bord0\\shad0\\pos(%f,%f)}'):format(icon_x, icon_y)
+
+	-- mpv logo
+	for _, line in ipairs(self.logo_lines) do
+		ass:new_event()
+		ass:append(line_prefix .. line)
+	end
+
+	-- Santa hat
+	if state.is_december and not options.greenandgrumpy then
+		for _, line in ipairs(self.santa_hat_lines) do
+			ass:new_event()
+			ass:append(line_prefix .. line)
+		end
+	end
+
+	ass:txt(display.width / 2, icon_y + logo_size + spacing, 8, 'Drop files or URLs to play here.', {size = font_size})
+
+	return ass
+end
+
 --[[ PauseIndicator ]]
 
 ---@class PauseIndicator : Element
@@ -3777,6 +3851,7 @@ end
 
 --[[ CREATE STATIC ELEMENTS ]]
 
+Logo:new()
 WindowBorder:new()
 PauseIndicator:new()
 TopBar:new()
@@ -4736,3 +4811,12 @@ mp.register_script_message('set', function(name, value)
 end)
 mp.register_script_message('toggle-elements', function(elements) Elements:toggle(split(elements, ' *, *')) end)
 mp.register_script_message('flash-elements', function(elements) Elements:flash(split(elements, ' *, *')) end)
+mp.register_script_message('osc-idlescreen', function(mode, no_osd)
+    if mode == 'cycle' then mode = state.idlescreen and 'no' or 'yes' end
+    set_state('idlescreen', mode == 'yes')
+    utils.shared_script_property_set('osc-idlescreen', mode)
+
+    if not no_osd and mp.get_property_number('osd-level', 1) >= 1 then
+        mp.osd_message('OSC logo visibility: ' .. tostring(mode))
+    end
+end)


### PR DESCRIPTION
We can't make the logo scale with window size, like it does in osc.lua, so I decided to make it bigger by a factor of 2.

Changing the size by factors of 2 is easy, but dynamically scaling it's size would require us to take the strings from the logo table and make lists with them where we then scale each number before converting to a string. This would also be required if we were to implement hidpi support that actually renders in native resolution.

osc.lua renders with a fixed vertical resolution of 360, so they get their scaling for free.

I've asked in the IRC if anyone has a problem with this, but no answer in the 6.5 hours since.