### PR TITLE
fix: options.click_threshold

### DIFF
--- a/script-opts/uosc.conf
+++ b/script-opts/uosc.conf
@@ -142,6 +142,7 @@ font_scale=1
 # Border of text and icons when drawn directly on top of video
 text_border=1.2
 # Execute command for background clicks shorter than this number of milliseconds, 0 to disable
+# Filters out double clicks based on `input-doubleclick-time`
 click_threshold=0
 click_command=cycle pause; script-binding uosc/flash-pause-indicator
 # Flash duration in milliseconds used by `flash-{element}` commands


### PR DESCRIPTION
It's a stripped down version of https://gist.github.com/christoph-heinrich/a3e7fdf1ed24e8625f5f9934ebe1313a

Clicks are only registered when the window can't be dragged around. I don't know if that is how you want it to behave, but with window dragging also being left click, it's ambiguous how it should behave.

Also dragging when the window is currently not dragable is also filtered out with a threshold.