### PR TITLE
fix: compatible with multiple comments

### DIFF
--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -303,11 +303,16 @@ local config = {
 		local by_id = {}
 
 		for line in io.lines(input_conf_path) do
-			local key, command, title = string.match(line, '%s*([%S]+)%s+(.-)%s+#!%s*(.-)%s*$')
-			if not key then
-				key, command, title = string.match(line, '%s*([%S]+)%s+(.-)%s+#menu:%s*(.-)%s*$')
+			local key, command, comment = string.match(line, '%s*([%S]+)%s+(.-)%s+#%s*(.-)%s*$')
+			local title = ''
+			if comment then
+				local comments = split(comment, '#')
+				local titles = itable_filter(comments, function(v, i) return v:match('^!') or v:match('^menu:') end)
+				if titles and #titles > 0 then
+					title = titles[1]:match('^!%s*(.*)%s*') or titles[1]:match('^menu:%s*(.*)%s*')
+				end
 			end
-			if key then
+			if title ~= '' then
 				local is_dummy = key:sub(1, 1) == '#'
 				local submenu_id = ''
 				local target_menu = main_menu


### PR DESCRIPTION
Multiple code comments can conflict, fix it.

before:
![image](https://user-images.githubusercontent.com/50797982/195011212-65630f44-03b2-49ff-a388-e6e06cb20620.png)

after:
![image](https://user-images.githubusercontent.com/50797982/195011309-7c9ede81-dd79-46a5-94e5-7e3c2c568a92.png)

input.conf

```ini
z    set video-rotate 0     #menu: 测试 > rotate 0      #@click         # Comments
z    set video-rotate 90    #menu: 测试 > rotate 90     #@double_click
```
