### PR TITLE
fix: don't render empty title

### DIFF
--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -3221,8 +3221,8 @@ function TopBar:render()
 		end
 
 		-- Title
-		if max_bx - title_ax > self.font_size * 3 then
-			local text = state.title or 'n/a'
+		local text = state.title
+		if max_bx - title_ax > self.font_size * 3 and text and text ~= '' then
 			local bx = math.min(max_bx, title_ax + text_width_estimate(text, self.font_size) + padding * 2)
 			local by = self.by - bg_margin
 			ass:rect(title_ax, title_ay, bx, by, {


### PR DESCRIPTION
Prevents the empty rectangle seen in https://github.com/tomasklaen/uosc/pull/312#issuecomment-1275013070

The playlist indicator that's seen in the comment below that one is still shown when in idle after a playlist runs out.
That's technically correct as there still is a playlist, but maybe it would be better to hide it in order to have an empty corner again, just like when the player gets opened without files? I'm not sure...