### PR TITLE
fix: improve text width estimation

### DIFF
--- a/script-opts/uosc.conf
+++ b/script-opts/uosc.conf
@@ -176,10 +176,11 @@ stream_quality_options=4320,2160,1440,1080,720,480,360,240,144
 media_types=3g2,3gp,aac,aiff,ape,apng,asf,au,avi,avif,bmp,dsf,f4v,flac,flv,gif,h264,h265,j2k,jp2,jfif,jpeg,jpg,jxl,m2ts,m4a,m4v,mid,midi,mj2,mka,mkv,mov,mp3,mp4,mp4a,mp4v,mpeg,mpg,oga,ogg,ogm,ogv,opus,png,rm,rmvb,spx,svg,tak,tga,tta,tif,tiff,ts,vob,wav,weba,webm,webp,wma,wmv,wv,y4m
 # File types to look for when loading external subtitles
 subtitle_types=aqt,ass,gsub,idx,jss,lrc,mks,pgs,pjs,psb,rt,slt,smi,sub,sup,srt,ssa,ssf,ttxt,txt,usf,vt,vtt
-# Used to approximate text width
-# If you are using some wide font and see a lot of right side clipping in menus,
-# try bumping this up.
-font_height_to_letter_width_ratio=0.5
+# Text width approximation options
+# - enable if you're using a monospace font
+monospace=no
+# - tweak for fonts that are wider or narrower
+font_width_scale=1
 # Default open-file menu directory
 default_directory=~/
 


### PR DESCRIPTION
I'm working on improving text width estimation by creating a map of character widths relative to font size. Would love to hear some feedback and help/ideas on how to fix the current issues:

![image](https://user-images.githubusercontent.com/47283320/195317307-a3c5542e-17cf-44c5-a4f7-c39448ea3c98.png)

1. Some european characters are definitely missing.
2. It works well for most stuff, except some asian text (chinese characters on the screenshot).
3. I also don't like the idea of putting all drawing characters such as `└` into the table.

I guess we need a way to identify character ranges with similar widths, but I'm not sure about the best way how to do that here.

This is just a WIP PR that includes tests in the `render()` function.