### PR TITLE
fix: support checking URL without slashes

### DIFF
--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -738,7 +738,7 @@ end
 -- Check if path is a protocol, such as `http://...`
 ---@param path string
 function is_protocol(path)
-	return type(path) == 'string' and path:match('^%a[%a%d-_]+://') ~= nil
+	return type(path) == 'string' and (path:match('^%a[%a%d-_]+://') ~= nil or path:match('^%a[%a%d-_]+:\\?') ~= nil)
 end
 
 ---@param path string


### PR DESCRIPTION
It now supports checking URLs like this: `magnet:?`