### PR TITLE
perf: faster filename sorting

### DIFF
--- a/scripts/uosc/lib/menus.lua
+++ b/scripts/uosc/lib/menus.lua
@@ -167,7 +167,7 @@ function open_file_navigation_menu(directory_path, handle_select, opts)
 	end
 
 	-- Files are already sorted
-	table.sort(directories, file_order_comparator)
+	sort_filenames(directories)
 
 	-- Pre-populate items with parent directory selector if not at root
 	-- Each item value is a serialized path table it points to.


### PR DESCRIPTION
I measured a ~15 times speedup on that 1700 files folder I made out of dyphires config.

Numbers with leading zeros are now sorted after identical numbers without leading zeros.

ref. https://github.com/tomasklaen/uosc/pull/338#issuecomment-1290137738