### PR TITLE
perf: menu directory opening speedup

### DIFF
--- a/scripts/uosc/lib/menus.lua
+++ b/scripts/uosc/lib/menus.lua
@@ -197,8 +197,16 @@ function open_file_navigation_menu(directory_path, handle_select, opts)
 	end
 
 	for _, file in ipairs(files) do
-		local serialized = serialize_path(utils.join_path(directory.path, file))
-		if serialized then
+		if not is_protocol(file) then
+			local dot_split = split(file, '%.')
+			local serialized = {
+				path = utils.join_path(directory.path, file),
+				is_root = false,
+				dirname = directory.path,
+				basename = file,
+				filename = #dot_split > 1 and table.concat(itable_slice(dot_split, 1, #dot_split - 1), '.') or file,
+				extension = #dot_split > 1 and dot_split[#dot_split] or nil,
+			}
 			serialized.is_file = true
 			items[#items + 1] = {title = serialized.basename, value = serialized}
 		end


### PR DESCRIPTION
I've been digging into why opening large directories takes so long, because I know it's not because the width estimation takes that long, and sorting is now also pretty quick. It turns out there is a lot of work being done that really doesn't have to be done.

The vast majority of the time is spent in [this line](https://github.com/tomasklaen/uosc/blob/614ccf6b3ae5af35e2ed0b0a2884ba43c02755d3/scripts/uosc/lib/utils.lua#L204).

The time this one loop takes when opening my test folder went from ~880ms down to ~35ms.
From a quick look it seems that  `filename` and `extension` from that table is never actually used, and getting rid of those and `dot_split` lowers it even further to ~15ms.

I don't know how robust what I have here actually is, I haven't done a lot of testing and I doubt it will ever get into a mergeable state. The main point here is to show how much faster it could be. This only touches files and not directories, so directories containing lots of directories will still be slow.

You know a lot better then me which kinds of paths can come from where and what's actually needed.