### PR TITLE
perf: optimize serialize_path

### DIFF
--- a/scripts/uosc/lib/std.lua
+++ b/scripts/uosc/lib/std.lua
@@ -37,6 +37,20 @@ function split(str, pattern)
 	return list
 end
 
+---Get index of the last appearance of `sub` in `str`
+---@param str string
+---@param sub string
+---@return integer|nil
+function string.last_index_of(str, sub)
+	local sub_length = #sub
+	for i = #str, 1, -1 do
+		for j = 1, sub_length do
+			if str:byte(i + j - 1) ~= sub:byte(j) then break end
+			if j == sub_length then return i end
+		end
+	end
+end
+
 ---@param itable table
 ---@param value any
 ---@return integer|nil

--- a/scripts/uosc/lib/utils.lua
+++ b/scripts/uosc/lib/utils.lua
@@ -198,23 +198,17 @@ function serialize_path(path)
 	if not path or is_protocol(path) then return end
 
 	local normal_path = normalize_path(path)
-	-- normalize_path() already strips slashes, but leaves trailing backslash
-	-- for windows drive letters, but we don't need it here.
-	local working_path = normal_path:sub(#normal_path) == '\\' and normal_path:sub(1, #normal_path - 1) or normal_path
-	local parts = split(working_path, '[\\/]+')
-	local basename = parts and parts[#parts] or working_path
-	local dirname = #parts > 1
-		and table.concat(itable_slice(parts, 1, #parts - 1), state.os == 'windows' and '\\' or '/')
-		or nil
-	local dot_split = split(basename, '%.')
+	local dirname, basename = utils.split_path(normal_path)
+	if basename == '' then dirname = nil end
+	local dot_i = basename:last_index_of('.')
 
 	return {
 		path = normal_path,
 		is_root = dirname == nil,
 		dirname = dirname,
 		basename = basename,
-		filename = #dot_split > 1 and table.concat(itable_slice(dot_split, 1, #dot_split - 1), '.') or basename,
-		extension = #dot_split > 1 and dot_split[#dot_split] or nil,
+		filename = dot_i and basename:sub(1, dot_i - 1) or basename,
+		extension = dot_i and basename:sub(dot_i + 1) or nil,
 	}
 end
 


### PR DESCRIPTION
This is not just a performance improvement, but a bug fix as well. I used to not be possible to get to the root directory on linux, but now that works.

The loop I measured in #344 went from ~880ms down to ~40ms with this. There is still a lot of room for improvement, but this is already huge.

Splitting `working_path` with `last_index_of()` had identical performance to `utils.split_path()`, but using the built-in function is less code.

Creating `filename` and `extension` now only contributes ~1ms to the total time instead of ~20ms.