### PR TITLE
perf: optimize normalize_path

### DIFF
--- a/scripts/uosc/lib/std.lua
+++ b/scripts/uosc/lib/std.lua
@@ -17,6 +17,21 @@ function serialize_rgba(rgba)
 	}
 end
 
+---Trim any `char` from the end of the string
+---@param str string
+---@param char string
+---@return string
+function string.trim_end(str, char)
+	local char, end_i = char:byte(), nil
+	for i = #str, 1, -1 do
+		if str:byte(i) ~= char then
+			end_i = i
+			break
+		end
+	end
+	return str:sub(1, end_i)
+end
+
 ---@param str string
 ---@param pattern string
 ---@return string[]

--- a/scripts/uosc/lib/utils.lua
+++ b/scripts/uosc/lib/utils.lua
@@ -145,32 +145,26 @@ function opacity_to_alpha(opacity)
 	return 255 - math.ceil(255 * opacity)
 end
 
--- Ensures path is absolute and normalizes slashes to the current platform
+-- Ensures path is absolute and remove trailing slashes/backslashes
 ---@param path string
 function normalize_path(path)
 	if not path or is_protocol(path) then return path end
 
 	-- Ensure path is absolute
-	if not (path:match('^/') or path:match('^%a+:') or path:match('^\\\\')) then
+	if not (path:match(state.os == 'windows' and '^%a+:' or '^/') or path:match('^\\\\')) then
 		path = utils.join_path(state.cwd, path)
-	end
-
-	-- Remove trailing slashes
-	if #path > 1 then
-		path = path:gsub('[\\/]+$', '')
-		path = #path == 0 and '/' or path
 	end
 
 	-- Use proper slashes
 	if state.os == 'windows' then
+		path = path:trim_end('\\')
 		-- Drive letters on windows need trailing backslash
 		if path:sub(#path) == ':' then
 			path = path .. '\\'
 		end
-
-		return path:gsub('/', '\\')
+		return path
 	else
-		return path:gsub('\\', '/')
+		return path:trim_end('/')
 	end
 end
 


### PR DESCRIPTION
Does not convert backslashes to slashes or vice versa anymore.
Backslash is a valid character on Unix filesystems, so converting it to slash can actually break things.
I don't think it's possible to encounter a slash in a path on windows, except maybe from the `default_directory` option. If that's really a problem, we should sanitize that option at startup instead of always substituting in `normalize_path`.

This together with #346 brings the measured time on that file loop on my test directory down to ~18ms, getting surprisingly close to the time from #344.