### PR TITLE
fix: selection on mbtn_up requires mbtn_down first

### DIFF
--- a/scripts/uosc_shared/elements/Menu.lua
+++ b/scripts/uosc_shared/elements/Menu.lua
@@ -498,7 +498,7 @@ function Menu:fling_distance()
 end
 
 function Menu:on_global_mbtn_left_up()
-	if self.proximity_raw == 0 and not self.is_dragging then
+	if self.proximity_raw == 0 and self.drag_data and not self.is_dragging then
 		self:select_item_below_cursor()
 		self:open_selected_item({preselect_submenu_item = false})
 	end


### PR DESCRIPTION
Without checking if mbtn_down happened first in the menu, it is possible to select an item right after opening the menu from the controls. (mbtn_down on control opens menu, mbtn_up selects item in menu)
That is really annoying when the playlist menu is big enough to overlap with the control for opening the playlist.