### PR TITLE
fix: controls activating when overlapping chapter is clicked

### DIFF
--- a/scripts/uosc_shared/elements/Button.lua
+++ b/scripts/uosc_shared/elements/Button.lua
@@ -24,6 +24,8 @@ end
 
 function Button:on_coordinates() self.font_size = round((self.by - self.ay) * 0.7) end
 function Button:on_mbtn_left_down()
+	-- Don't accept clicks while hidden.
+	if self:get_visibility() <= 0 then return end
 	-- We delay the callback to next tick, otherwise we are risking race
 	-- conditions as we are in the middle of event dispatching.
 	-- For example, handler might add a menu to the end of the element stack, and that

--- a/scripts/uosc_shared/elements/Speed.lua
+++ b/scripts/uosc_shared/elements/Speed.lua
@@ -45,6 +45,8 @@ function Speed:speed_step(speed, up)
 end
 
 function Speed:on_mbtn_left_down()
+	-- Don't accept clicks while hidden.
+	if self:get_visibility() <= 0 then return end
 	self:tween_stop() -- Stop and cleanup possible ongoing animations
 	self.dragging = {
 		start_time = mp.get_time(),


### PR DESCRIPTION
Closes #371