### PR TITLE
fix: A-B loop crash

### DIFF
--- a/scripts/uosc_shared/elements/Timeline.lua
+++ b/scripts/uosc_shared/elements/Timeline.lua
@@ -298,8 +298,8 @@ function Timeline:render()
 				end
 			end
 
-			if state.ab_loop_a and state.ab_loop_a > 0 then draw_chapter(state.ab_loop_a) end
-			if state.ab_loop_b and state.ab_loop_b > 0 then draw_chapter(state.ab_loop_b) end
+			if state.ab_loop_a and state.ab_loop_a > 0 then draw_chapter(state.ab_loop_a, diamond_radius) end
+			if state.ab_loop_b and state.ab_loop_b > 0 then draw_chapter(state.ab_loop_b, diamond_radius) end
 		end
 	end
 


### PR DESCRIPTION
Fixes https://github.com/tomasklaen/uosc/issues/49#issuecomment-1348022899

This made me realize that a-b loop indicators aren't clickable even though they look the same as chapter indicators. Do we want that?