### PR TITLE
feat: add destination_time option and deprecate total_time

### DIFF
--- a/script-opts/uosc.conf
+++ b/script-opts/uosc.conf
@@ -163,7 +163,7 @@ background=000000
 background_text=ffffff
 # Use only bold font weight throughout the whole UI
 font_bold=no
-# One of 'total', 'playtime-remaining' (scaled by the current speed), 'time-remaining' (remaining length of file)
+# One of `total`, `playtime-remaining` (scaled by the current speed), `time-remaining` (remaining length of file)
 destination_time=playtime-remaining
 # Display sub second fraction in timestamps up to this precision
 time_precision=0

--- a/script-opts/uosc.conf
+++ b/script-opts/uosc.conf
@@ -163,8 +163,8 @@ background=000000
 background_text=ffffff
 # Use only bold font weight throughout the whole UI
 font_bold=no
-# Show total time instead of time remaining
-total_time=no
+# One of 'total', 'playtime-remaining' (scaled by the current speed), 'time-remaining' (remaining length of file)
+destination_time=playtime-remaining
 # Display sub second fraction in timestamps up to this precision
 time_precision=0
 # Display stream's buffered time in timeline if it's lower than this amount of seconds, 0 to disable

--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -113,6 +113,10 @@ if options.pause_on_click_shorter_than > 0 and options.click_threshold == 0 then
 	msg.warn('`pause_on_click_shorter_than` is deprecated. Use `click_threshold` and `click_command` instead.')
 	options.click_threshold = options.pause_on_click_shorter_than
 end
+if options.total_time and options.destination_time == 'playtime-remaining' then
+	msg.warn('`total_time` is deprecated. Use `destination_time` instead.')
+	options.destination_time = 'total'
+end
 -- Ensure required environment configuration
 if options.autoload then mp.commandv('set', 'keep-open-pause', 'no') end
 -- Color shorthands
@@ -370,12 +374,12 @@ function update_human_times()
 		state.time_human = format_time(state.time)
 		if state.duration then
 			local speed = state.speed or 1
-      if options.total_time or options.destination_time == "total" then
-        state.duration_or_remaining_time_human = format_time(state.duration)
-      elseif options.destination_time == "time-remaining" then
-        state.duration_or_remaining_time_human = format_time(state.time - state.duration)
-      else
+      if options.destination_time == 'playtime_remaining' then
         state.duration_or_remaining_time_human = format_time((state.time - state.duration) / speed)
+      elseif options.destination_time == 'total' then
+        state.duration_or_remaining_time_human = format_time(state.duration)
+      else
+        state.duration_or_remaining_time_human = format_time(state.time - state.duration)
       end
 		else
 			state.duration_or_remaining_time_human = nil

--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -1,5 +1,5 @@
---[[ uosc 4.6.0 - 2022-Dec-25 | https://github.com/tomasklaen/uosc ]]
-local uosc_version = '4.6.0'
+--[[ uosc 4.5.0 - 2022-Dec-07 | https://github.com/tomasklaen/uosc ]]
+local uosc_version = '4.5.0'
 
 assdraw = require('mp.assdraw')
 opt = require('mp.options')

--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -290,7 +290,7 @@ state = {
 	speed = 1,
 	duration = nil, -- current media duration
 	time_human = nil, -- current playback time in human format
-	duration_or_remaining_time_human = nil, -- depends on options.total_time
+	destination_time_human = nil, -- depends on options.destination_time
 	pause = mp.get_property_native('pause'),
 	chapters = {},
 	current_chapter = nil,
@@ -375,14 +375,14 @@ function update_human_times()
 		if state.duration then
 			local speed = state.speed or 1
       if options.destination_time == 'playtime_remaining' then
-        state.duration_or_remaining_time_human = format_time((state.time - state.duration) / speed)
+        state.destination_time_human = format_time((state.time - state.duration) / speed)
       elseif options.destination_time == 'total' then
-        state.duration_or_remaining_time_human = format_time(state.duration)
+        state.destination_time_human = format_time(state.duration)
       else
-        state.duration_or_remaining_time_human = format_time(state.time - state.duration)
+        state.destination_time_human = format_time(state.time - state.duration)
       end
 		else
-			state.duration_or_remaining_time_human = nil
+			state.destination_time_human = nil
 		end
 	else
 		state.time_human = nil

--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -1,5 +1,5 @@
---[[ uosc 4.5.0 - 2022-Dec-07 | https://github.com/tomasklaen/uosc ]]
-local uosc_version = '4.5.0'
+--[[ uosc 4.6.0 - 2022-Dec-25 | https://github.com/tomasklaen/uosc ]]
+local uosc_version = '4.6.0'
 
 assdraw = require('mp.assdraw')
 opt = require('mp.options')
@@ -88,7 +88,8 @@ defaults = {
 	foreground_text = '000000',
 	background = '000000',
 	background_text = 'ffffff',
-	total_time = false,
+	total_time = false, -- deprecated by below
+	destination_time = 'playtime-remaining',
 	time_precision = 0,
 	font_bold = false,
 	autohide = false,
@@ -369,9 +370,13 @@ function update_human_times()
 		state.time_human = format_time(state.time)
 		if state.duration then
 			local speed = state.speed or 1
-			state.duration_or_remaining_time_human = format_time(
-				options.total_time and state.duration or ((state.time - state.duration) / speed)
-			)
+      if options.total_time or options.destination_time == "total" then
+        state.duration_or_remaining_time_human = format_time(state.duration)
+      elseif options.destination_time == "time-remaining" then
+        state.duration_or_remaining_time_human = format_time(state.time - state.duration)
+      else
+        state.duration_or_remaining_time_human = format_time((state.time - state.duration) / speed)
+      end
 		else
 			state.duration_or_remaining_time_human = nil
 		end

--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -116,6 +116,8 @@ end
 if options.total_time and options.destination_time == 'playtime-remaining' then
 	msg.warn('`total_time` is deprecated. Use `destination_time` instead.')
 	options.destination_time = 'total'
+elseif not itable_index_of({'total', 'playtime-remaining', 'time-remaining'}, options.destination_time) then
+	options.destination_time = 'playtime-remaining'
 end
 -- Ensure required environment configuration
 if options.autoload then mp.commandv('set', 'keep-open-pause', 'no') end

--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -374,13 +374,13 @@ function update_human_times()
 		state.time_human = format_time(state.time)
 		if state.duration then
 			local speed = state.speed or 1
-      if options.destination_time == 'playtime_remaining' then
-        state.destination_time_human = format_time((state.time - state.duration) / speed)
-      elseif options.destination_time == 'total' then
-        state.destination_time_human = format_time(state.duration)
-      else
-        state.destination_time_human = format_time(state.time - state.duration)
-      end
+			if options.destination_time == 'playtime_remaining' then
+				state.destination_time_human = format_time((state.time - state.duration) / speed)
+			elseif options.destination_time == 'total' then
+				state.destination_time_human = format_time(state.duration)
+			else
+				state.destination_time_human = format_time(state.time - state.duration)
+			end
 		else
 			state.destination_time_human = nil
 		end

--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -376,7 +376,7 @@ function update_human_times()
 		state.time_human = format_time(state.time)
 		if state.duration then
 			local speed = state.speed or 1
-			if options.destination_time == 'playtime_remaining' then
+			if options.destination_time == 'playtime-remaining' then
 				state.destination_time_human = format_time((state.time - state.duration) / speed)
 			elseif options.destination_time == 'total' then
 				state.destination_time_human = format_time(state.duration)

--- a/scripts/uosc_shared/elements/Timeline.lua
+++ b/scripts/uosc_shared/elements/Timeline.lua
@@ -333,8 +333,8 @@ function Timeline:render()
 		end
 
 		-- End time
-		if state.duration_or_remaining_time_human then
-			draw_timeline_text(bbx - spacing, fcy, 6, state.duration_or_remaining_time_human, time_opts)
+		if state.destination_time_human then
+			draw_timeline_text(bbx - spacing, fcy, 6, state.destination_time_human, time_opts)
 		end
 	end
 


### PR DESCRIPTION
Resolves #397

I used `playtime-remaining` and `time-remaining` because this is how the are described in mpv documentation.