### PR TITLE
Add integration with mpv-quality-menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,9 @@ Editions menu. Editions are different video cuts available in some mkv files.
 
 #### `stream-quality`
 
-Switch stream quality. This is just a basic re-assignment of `ytdl-format` mpv property from predefined options (configurable with `stream_quality_options`) and video reload, there is no fetching of available formats going on.
+Switch stream quality.
+
+This is just a basic re-assignment of `ytdl-format` mpv property from predefined options (configurable with `stream_quality_options`) and video reload. There is no fetching of available formats going on. However, if the special value `stream_quality_options=script` is set, uosc will try to open the menu of quality-menu.lua instead, which fetches the available formats. For installation see [mpv-quality-menu](https://github.com/christoph-heinrich/mpv-quality-menu).
 
 #### `open-file`
 

--- a/script-opts/uosc.conf
+++ b/script-opts/uosc.conf
@@ -175,7 +175,9 @@ autohide=no
 pause_indicator=flash
 # Screen dim when stuff like menu is open, 0 to disable
 curtain_opacity=0.5
-# Sizes to list in stream quality menu
+# Sizes (pixel height) to list in stream quality menu.
+# The special value "stream_quality_options=script" will try to open the menu of quality-menu.lua, which fetches the available formats.
+# "script" as a value requires this script to be installed: https://github.com/christoph-heinrich/mpv-quality-menu
 stream_quality_options=4320,2160,1440,1080,720,480,360,240,144
 # File types to look for when navigating media files
 media_types=3g2,3gp,aac,aiff,ape,apng,asf,au,avi,avif,bmp,dsf,dts,f4v,flac,flv,gif,h264,h265,j2k,jp2,jfif,jpeg,jpg,jxl,m2ts,m4a,m4v,mid,midi,mj2,mka,mkv,mov,mp3,mp4,mp4a,mp4v,mpeg,mpg,oga,ogg,ogm,ogv,opus,png,rm,rmvb,spx,svg,tak,tga,tta,tif,tiff,ts,vob,wav,weba,webm,webp,wma,wmv,wv,y4m

--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -855,6 +855,12 @@ end)
 mp.add_key_binding(nil, 'stream-quality', function()
 	if Menu:is_open('stream-quality') then Menu:close() return end
 
+	-- If set in config, delegate the stream quality menu to external script 
+	if options.stream_quality_options == 'script' then
+		mp.command('script-binding quality_menu/video_formats_toggle')
+	    return
+	end
+
 	local ytdl_format = mp.get_property_native('ytdl-format')
 	local items = {}
 


### PR DESCRIPTION
Integrates @christoph-heinrich excellent [mpv-quality-menu](https://github.com/christoph-heinrich/mpv-quality-menu) script.

I added one if-statement that delegates `script-binding uosc/stream-quality` to `script-binding quality_menu/video_formats_toggle`, if the special value `stream_quality_options=script` is set for the already existing config option.

This simplifies the setup for the script a lot, because the user doesn't have to manually modify the control button and menu entry for the built-in quality-menu.

There is some context at https://github.com/tomasklaen/uosc/pull/102