### PR TITLE
fix: constant width for hovered time

### DIFF
--- a/scripts/uosc_shared/elements/Timeline.lua
+++ b/scripts/uosc_shared/elements/Timeline.lua
@@ -358,7 +358,7 @@ function Timeline:render()
 		local offset = #state.chapters > 0 and 10 or 4
 		local opts = {size = self.font_size, offset = offset}
 		local hovered_time_human = format_time(hovered_seconds, state.duration)
-		opts.width_overwrite = text_width(hovered_time_human, opts)
+		opts.width_overwrite = text_width(hovered_time_human:gsub('%d', '0'), opts)
 		ass:tooltip(tooltip_anchor, hovered_time_human, opts)
 		tooltip_anchor.ay = tooltip_anchor.ay - self.font_size - offset
 


### PR DESCRIPTION
Without this the text jumps around a bit on the edges where the position gets clamped.