### PR TITLE
feat: add `on_close` command to menu API

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@ Menu {
   items: Item[];
   selected_index?: integer;
   keep_open?: boolean;
+  on_close: string | string[];
 }
 
 Item = Command | Submenu;
@@ -430,9 +431,9 @@ Command {
 }
 ```
 
-When command value is a string, it'll be passed to `mp.command(value)`. If it's a table (array) of strings, it'll be used as `mp.commandv(table.unpack(value))`.
+When `Command.value` is a string, it'll be passed to `mp.command(value)`. If it's a table (array) of strings, it'll be used as `mp.commandv(table.unpack(value))`. The same goes for `Menu.on_close`.
 
-Menu `type` controls what happens when opening a menu when some other menu is already open. When the new menu type is different, it'll replace the currently opened menu. When it's the same, the currently open menu will simply be closed. This is used to implement toggling of menus with the same type.
+`Menu.type` controls what happens when opening a menu when some other menu is already open. When the new menu type is different, it'll replace the currently opened menu. When it's the same, the currently open menu will simply be closed. This is used to implement toggling of menus with the same type.
 
 `item.icon` property accepts icon names. You can pick one from here: [Google Material Icons](https://fonts.google.com/icons?selected=Material+Icons)\
 There is also a special icon name `spinner` which will display a rotating spinner. Along with a no-op command on an item and `keep_open=true`, this can be used to display placeholder menus/items that are still loading.

--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -1116,7 +1116,7 @@ mp.register_script_message('open-menu', function(json, submenu_id)
 		msg.error('open-menu: received json didn\'t produce a table with menu configuration')
 	else
 		if data.type and Menu:is_open(data.type) then Menu:close()
-		else open_command_menu(data, {submenu_id = submenu_id}) end
+		else open_command_menu(data, {submenu = submenu_id, on_close = data.on_close}) end
 	end
 end)
 mp.register_script_message('update-menu', function(json)

--- a/scripts/uosc_shared/lib/menus.lua
+++ b/scripts/uosc_shared/lib/menus.lua
@@ -1,19 +1,26 @@
 ---@param data MenuData
----@param opts? {submenu?: string; mouse_nav?: boolean}
+---@param opts? {submenu?: string; mouse_nav?: boolean; on_close?: string | string[]}
 function open_command_menu(data, opts)
-	local menu = Menu:open(data, function(value)
-		if type(value) == 'string' then
-			mp.command(value)
+	local function run_command(command)
+		if type(command) == 'string' then
+			mp.command(command)
 		else
 			---@diagnostic disable-next-line: deprecated
-			mp.commandv(unpack(value))
+			mp.commandv(unpack(command))
 		end
-	end, opts)
+	end
+	---@type MenuOptions
+	local menu_opts = {}
+	if opts then
+		menu_opts.submenu, menu_opts.mouse_nav = opts.submenu, opts.mouse_nav
+		if opts.on_close then menu_opts.on_close = function() run_command(opts.on_close) end end
+	end
+	local menu = Menu:open(data, run_command, menu_opts)
 	if opts and opts.submenu then menu:activate_submenu(opts.submenu) end
 	return menu
 end
 
----@param opts? {submenu?: string; mouse_nav?: boolean}
+---@param opts? {submenu?: string; mouse_nav?: boolean; on_close?: string | string[]}
 function toggle_menu_with_items(opts)
 	if Menu:is_open('menu') then Menu:close()
 	else open_command_menu({type = 'menu', items = config.menu_items}, opts) end


### PR DESCRIPTION
Creating the new table is required to appease the type checker. I also had a version that just told the type checker to shut up, but it required a temporary variable, making the whole thing not really any shorter.

This doesn't work with `update-menu` because there is currently no way of updating `opts` and I'm not sure that's useful enough to make that happen.

Also there was a bug where `opts.submenu_id` got set instead of `opts.submenu`.

Closes #448