### PR TITLE
Chapter range patterns

### DIFF
--- a/scripts/uosc_shared/lib/utils.lua
+++ b/scripts/uosc_shared/lib/utils.lua
@@ -430,7 +430,7 @@ function serialize_chapter_ranges(normalized_chapters)
 	local simple_ranges = {
 		{name = 'openings', patterns = {'^op ', '^op$', ' op$', 'opening$'}, requires_next_chapter = true},
 		{name = 'intros', patterns = {'^intro$'}, requires_next_chapter = true},
-		{name = 'endings', patterns = {'^ed ', '^ed$', ' ed$', 'ending$', 'closing$'}},
+		{name = 'endings', patterns = {'^ed ', '^ed$', ' ed$', '^ending ', '^ending$', ' ending$', 'closing$'}},
 		{name = 'outros', patterns = {'^outro$'}},
 	}
 	local sponsor_ranges = {}

--- a/scripts/uosc_shared/lib/utils.lua
+++ b/scripts/uosc_shared/lib/utils.lua
@@ -428,9 +428,16 @@ end
 function serialize_chapter_ranges(normalized_chapters)
 	local ranges = {}
 	local simple_ranges = {
-		{name = 'openings', patterns = {'^op ', '^op$', ' op$', 'opening$'}, requires_next_chapter = true},
+		{name = 'openings', patterns = {
+				'^op ', '^op$', ' op$',
+				'^opening ', '^opening$', ' opening$',
+			}, requires_next_chapter = true},
 		{name = 'intros', patterns = {'^intro$'}, requires_next_chapter = true},
-		{name = 'endings', patterns = {'^ed ', '^ed$', ' ed$', '^ending ', '^ending$', ' ending$', 'closing$'}},
+		{name = 'endings', patterns = {
+				'^ed ', '^ed$', ' ed$',
+				'^ending ', '^ending$', ' ending$',
+				'^closing ', '^closing$', ' closing$'
+			}},
 		{name = 'outros', patterns = {'^outro$'}},
 	}
 	local sponsor_ranges = {}

--- a/scripts/uosc_shared/lib/utils.lua
+++ b/scripts/uosc_shared/lib/utils.lua
@@ -430,15 +430,21 @@ function serialize_chapter_ranges(normalized_chapters)
 	local simple_ranges = {
 		{name = 'openings', patterns = {
 				'^op ', '^op$', ' op$',
-				'^opening ', '^opening$', ' opening$',
+				'^opening$', ' opening$'
 			}, requires_next_chapter = true},
-		{name = 'intros', patterns = {'^intro$'}, requires_next_chapter = true},
+		{name = 'intros', patterns = {
+				'^intro$', ' intro$',
+				'^avant$', '^prologue$'
+			}, requires_next_chapter = true},
 		{name = 'endings', patterns = {
 				'^ed ', '^ed$', ' ed$',
 				'^ending ', '^ending$', ' ending$',
-				'^closing ', '^closing$', ' closing$'
 			}},
-		{name = 'outros', patterns = {'^outro$'}},
+		{name = 'outros', patterns = {
+				'^outro$', ' outro$',
+				'^closing$', '^closing ',
+				'^preview$', '^pv$',
+			}},
 	}
 	local sponsor_ranges = {}
 


### PR DESCRIPTION
I've recently encountered a few videos with false positives for `endings`. Turns out it's because chapters ending with e.g. 'trending' would be detected as an ending. To fix that I've now applied the same pattern for 'ending' as was already used for 'ed'.

While doing that I've noticed that 'opening' and 'closing' were also the same way, so I've applied the same thing to them too, but since I've never actually noticed any problems with them, I've made it a separate commit. Also I don't know if having all three variants even makes sense for all of them.

This is a draft because I'm not sure about the change and it could certainly benefit from testing and discussion.

A collection of examples of what should and shouldn't be detected for each kind would take a lot of the guesswork out of such changes. I've prepared  a table in a test file (not included here) to collect examples I encounter in the wild, let's see if that will ever become good enough to be useful.