### PR TITLE
Add support for the new user-data property

### DIFF
--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -431,6 +431,7 @@ function update_margins()
 	state.margin_bottom = bottom
 
 	utils.shared_script_property_set('osc-margins', string.format('%f,%f,%f,%f', 0, 0, top, bottom))
+	mp.set_property_native("user-data/osc/margins", { l = 0, r = 0, t = top, b = bottom })
 end
 function create_state_setter(name, callback)
 	return function(_, value)


### PR DESCRIPTION
A recently merged PR https://github.com/mpv-player/mpv/pull/11226 made the console use the new `user-data` property instead of shared-script-properties, resulting in our margins being ignored.

This sets the `user-data/osc/margins` property in addition to the old shared-script-property to keep compatiblity with older mpv versions.

The `user-data` property was introduced in https://github.com/mpv-player/mpv/pull/11013.