### PR TITLE
feat: apply margin to `osd-margin-y`

### DIFF
--- a/script-opts/uosc.conf
+++ b/script-opts/uosc.conf
@@ -200,6 +200,8 @@ default_directory=~/
 # - Linux: `sudo apt install trash-cli`
 # - MacOS: `brew install trash`
 use_trash=no
+# Adjusted osd margins based on the visibility of UI elements
+adjust_osd_margins=yes
 
 # Adds chapter range indicators to some common chapter types.
 # Additionally to displaying the start of the chapter as a diamond icon on top of the timeline,

--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -170,6 +170,10 @@ config = {
 	-- native rendering frequency could not be detected
 	render_delay = 1 / 60,
 	font = mp.get_property('options/osd-font'),
+	osd_margin_x = mp.get_property('osd-margin-x'),
+	osd_margin_y = mp.get_property('osd-margin-y'),
+	osd_alignment_x = mp.get_property('osd-align-x'),
+	osd_alignment_y = mp.get_property('osd-align-y'),
 	types = {
 		video = split(options.video_types, ' *, *'),
 		audio = split(options.audio_types, ' *, *'),
@@ -399,6 +403,8 @@ state = {
 	playlist_pos = 0,
 	margin_top = 0,
 	margin_bottom = 0,
+	margin_left = 0,
+	margin_right = 0,
 	hidpi_scale = 1,
 }
 thumbnail = {width = 0, height = 0, disabled = false}
@@ -464,21 +470,37 @@ function update_margins()
 	if display.height == 0 then return end
 
 	-- margins are normalized to window size
-	local timeline, top_bar, controls = Elements.timeline, Elements.top_bar, Elements.controls
+	local timeline, top_bar, controls, volume = Elements.timeline, Elements.top_bar, Elements.controls, Elements.volume
 	local bottom_y = controls and controls.enabled and controls.ay or timeline.ay
-	local top, bottom = 0, (display.height - bottom_y) / display.height
+	local left, right, top, bottom = 0, 0, 0, (display.height - bottom_y) / display.height
 
 	if top_bar.enabled and top_bar:get_visibility() > 0 then
 		top = (top_bar.size or 0) / display.height
 	end
 
-	if top == state.margin_top and bottom == state.margin_bottom then return end
+	if volume and volume.enabled and volume:is_persistent() then
+		if options.volume == 'left' then left = volume.bx / display.width
+		elseif options.volume == 'right' then right = volume.ax / display.width end
+	end
+
+	if top == state.margin_top and bottom == state.margin_bottom and
+		left == state.margin_left and right == state.margin_right then return end
 
 	state.margin_top = top
 	state.margin_bottom = bottom
+	state.margin_left = left
+	state.margin_right = right
 
 	utils.shared_script_property_set('osc-margins', string.format('%f,%f,%f,%f', 0, 0, top, bottom))
-	mp.set_property_native("user-data/osc/margins", { l = 0, r = 0, t = top, b = bottom })
+	mp.set_property_native('user-data/osc/margins', { l = left, r = right, t = top, b = bottom })
+
+	local osd_margin_y, osd_margin_x, osd_factor_x = 0, 0, display.width / display.height * 720
+	if config.osd_alignment_y == 'bottom' then osd_margin_y = round(bottom * 720)
+	elseif config.osd_alignment_y == 'top' then osd_margin_y = round(top * 720) end
+	if config.osd_alignment_x == 'left' then osd_margin_x = round(left * osd_factor_x)
+	elseif config.osd_alignment_x == 'right' then osd_margin_x = round(right * osd_factor_x) end
+	mp.set_property_native('osd-margin-y', osd_margin_y + config.osd_margin_y)
+	mp.set_property_native('osd-margin-x', osd_margin_x + config.osd_margin_x)
 end
 function create_state_setter(name, callback)
 	return function(_, value)

--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -106,6 +106,7 @@ defaults = {
 	subtitle_types = 'aqt,ass,gsub,idx,jss,lrc,mks,pgs,pjs,psb,rt,slt,smi,sub,sup,srt,ssa,ssf,ttxt,txt,usf,vt,vtt',
 	default_directory = '~/',
 	use_trash = false,
+	adjust_osd_margins = true,
 	chapter_ranges = 'openings:30abf964,endings:30abf964,ads:c54e4e80',
 	chapter_range_patterns = 'openings:オープニング;endings:エンディング',
 }
@@ -495,6 +496,7 @@ function update_margins()
 	utils.shared_script_property_set('osc-margins', string.format('%f,%f,%f,%f', 0, 0, top, bottom))
 	mp.set_property_native('user-data/osc/margins', { l = left, r = right, t = top, b = bottom })
 
+	if not options.adjust_osd_margins then return end
 	local osd_margin_y, osd_margin_x, osd_factor_x = 0, 0, display.width / display.height * 720
 	if config.osd_alignment_y == 'bottom' then osd_margin_y = round(bottom * 720)
 	elseif config.osd_alignment_y == 'top' then osd_margin_y = round(top * 720) end

--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -474,8 +474,8 @@ function update_margins()
 	local bottom_y = controls and controls.enabled and controls.ay or timeline.ay
 	local left, right, top, bottom = 0, 0, 0, (display.height - bottom_y) / display.height
 
-	if top_bar.enabled and top_bar:get_visibility() > 0 then
-		top = (top_bar.size or 0) / display.height
+	if top_bar.enabled and top_bar:is_persistent() then
+		top = top_bar.title_by / display.height
 	end
 
 	if volume and volume.enabled and volume:is_persistent() then

--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -469,16 +469,17 @@ end
 function update_margins()
 	if display.height == 0 then return end
 
-	-- margins are normalized to window size
+	local function is_persistent(element) return element and element.enabled and element:is_persistent() end
 	local timeline, top_bar, controls, volume = Elements.timeline, Elements.top_bar, Elements.controls, Elements.volume
-	local bottom_y = controls and controls.enabled and controls.ay or timeline.ay
-	local left, right, top, bottom = 0, 0, 0, (display.height - bottom_y) / display.height
+	-- margins are normalized to window size
+	local left, right, top, bottom = 0, 0, 0, 0
 
-	if top_bar.enabled and top_bar:is_persistent() then
-		top = top_bar.title_by / display.height
-	end
+	if is_persistent(controls) then bottom = (display.height - controls.ay) / display.height
+	elseif is_persistent(timeline) then bottom = (display.height - timeline.ay) / display.height end
 
-	if volume and volume.enabled and volume:is_persistent() then
+	if is_persistent(top_bar) then top = top_bar.title_by / display.height end
+
+	if is_persistent(volume) then
 		if options.volume == 'left' then left = volume.bx / display.width
 		elseif options.volume == 'right' then right = volume.ax / display.width end
 	end

--- a/scripts/uosc_shared/elements/Element.lua
+++ b/scripts/uosc_shared/elements/Element.lua
@@ -70,7 +70,7 @@ function Element:is_persistent()
 	local persist = config[self.id .. '_persistency']
 	return persist and (
 		(persist.audio and state.is_audio)
-		or (persist.paused and state.pause)
+		or (persist.paused and state.pause and (not Elements.timeline.pressed or Elements.timeline.pressed.pause))
 		or (persist.video and state.is_video)
 		or (persist.image and state.is_image)
 		or (persist.idle and state.is_idle)

--- a/scripts/uosc_shared/elements/Element.lua
+++ b/scripts/uosc_shared/elements/Element.lua
@@ -66,6 +66,17 @@ function Element:update_proximity()
 	end
 end
 
+function Element:is_persistent()
+	local persist = config[self.id .. '_persistency']
+	return persist and (
+		(persist.audio and state.is_audio)
+		or (persist.paused and state.pause)
+		or (persist.video and state.is_video)
+		or (persist.image and state.is_image)
+		or (persist.idle and state.is_idle)
+	)
+end
+
 -- Decide elements visibility based on proximity and various other factors
 function Element:get_visibility()
 	-- Hide when menu is open, unless this is a menu
@@ -73,14 +84,7 @@ function Element:get_visibility()
 	if not self.ignores_menu and Menu and Menu:is_open() then return 0 end
 
 	-- Persistency
-	local persist = config[self.id .. '_persistency']
-	if persist and (
-		(persist.audio and state.is_audio)
-			or (persist.paused and state.pause)
-			or (persist.video and state.is_video)
-			or (persist.image and state.is_image)
-			or (persist.idle and state.is_idle)
-		) then return 1 end
+	if self:is_persistent() then return 1 end
 
 	-- Forced visibility
 	if self.forced_visibility then return math.max(self.forced_visibility, self.min_visibility) end

--- a/scripts/uosc_shared/elements/TopBar.lua
+++ b/scripts/uosc_shared/elements/TopBar.lua
@@ -48,10 +48,8 @@ local TopBar = class(Element)
 function TopBar:new() return Class.new(self) --[[@as TopBar]] end
 function TopBar:init()
 	Element.init(self, 'top_bar')
-	self.size, self.size_max, self.size_min = 0, 0, 0
-	self.icon_size, self.spacing, self.font_size, self.title_bx = 1, 1, 1, 1
-	self.size_min_override = options.timeline_start_hidden and 0 or nil
-	self.top_border = options.timeline_border
+	self.size = 0
+	self.icon_size, self.spacing, self.font_size, self.title_bx, self.title_by = 1, 1, 1, 1, 1
 	self.show_alt_title = false
 	self.main_title, self.alt_title = nil, nil
 
@@ -241,8 +239,12 @@ function TopBar:render()
 					color = bg, opacity = visibility * options.top_bar_title_opacity, radius = 2,
 				})
 				ass:txt(title_ax + padding, title_ay + height / 2, 4, text, opts)
+				title_ay = by + 1
 			end
 		end
+		self.title_by = title_ay - 1
+	else
+		self.title_by = self.ay
 	end
 
 	return ass


### PR DESCRIPTION
The margins were already set for `osc-margins` and `user-data/osc/margins`, but osd messages have their own properties `osd-margin-y` and `osd-margin-x`.
Offsetting `osd-margin-y` by our margin prevents overlap of osd messages with the GUI.

ref. https://github.com/tomasklaen/uosc/discussions/498