### PR TITLE
fix: translate audio channels and devices list

### DIFF
--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -1174,7 +1174,7 @@ bind_command('audio-device', create_self_updating_menu_opener({
 				local hint = string.match(device.name, ao .. '/(.+)')
 				if not hint then hint = device.name end
 				items[#items + 1] = {
-					title = device.description,
+					title = device.description:sub(1, 7) == 'Default' and t('Default %s', device.description:sub(9)) or t(device.description),
 					hint = hint,
 					active = device.name == current_device,
 					value = device.name,

--- a/scripts/uosc_shared/lib/menus.lua
+++ b/scripts/uosc_shared/lib/menus.lua
@@ -106,7 +106,7 @@ function create_select_tracklist_type_menu_opener(menu_title, track_type, track_
 				end
 				if track['demux-fps'] then h(string.format('%.5gfps', track['demux-fps'])) end
 				h(track.codec)
-				if track['audio-channels'] then h(track['audio-channels'] .. ' channels') end
+				if track['audio-channels'] then h(t('%d channels', track['audio-channels'])) end
 				if track['demux-samplerate'] then h(string.format('%.3gkHz', track['demux-samplerate'] / 1000)) end
 				if track.forced then h(t('forced')) end
 				if track.default then h(t('default')) end


### PR DESCRIPTION
The channel count in track list couldn't be translated.
Also translate mpv's hardcoded entries in the audio devices list.