### PR TITLE
perf: cache menu title translation

### DIFF
--- a/scripts/uosc_shared/elements/Menu.lua
+++ b/scripts/uosc_shared/elements/Menu.lua
@@ -799,7 +799,7 @@ function Menu:render()
 		if draw_title then
 			local title_ay = ay - self.item_height
 			local title_height = self.item_height - 3
-			menu.ass_safe_title = t(menu.ass_safe_title or ass_escape(menu.title))
+			menu.ass_safe_title = menu.ass_safe_title or ass_escape(t(menu.title))
 
 			-- Background
 			ass:rect(ax + 2, title_ay, bx - 2, title_ay + title_height, {


### PR DESCRIPTION
The translation function was repeatedly called when a menu title bar was displayed.
Also escape title post-translation.