### PR TITLE
fix: translate topbar when no file

### DIFF
--- a/scripts/uosc_shared/elements/TopBar.lua
+++ b/scripts/uosc_shared/elements/TopBar.lua
@@ -85,6 +85,10 @@ function TopBar:decide_titles()
 	self.alt_title = state.alt_title ~= '' and state.alt_title or nil
 	self.main_title = state.title ~= '' and state.title or nil
 
+	if (self.main_title == 'No file') then
+		self.main_title = t('No file')
+	end
+
 	-- Fall back to alt title if main is empty
 	if not self.main_title then
 		self.main_title, self.alt_title = self.alt_title, nil


### PR DESCRIPTION
Need to add translation, after https://github.com/tomasklaen/uosc/pull/532 and https://github.com/tomasklaen/uosc/pull/534.