### PR TITLE
fix: translate fallback chapter title

### DIFF
--- a/scripts/uosc_shared/intl/de.json
+++ b/scripts/uosc_shared/intl/de.json
@@ -5,6 +5,7 @@
     "Audio devices": "Audiogeräte",
     "Audio tracks": "Audiospuren",
     "Autoselect device": "Automatische Geräteauswahl",
+    "Chapter %s": "Kapitel %s",
     "Chapters": "Kapitel",
     "Default": "Standard",
     "Default %s": "Standard %s",

--- a/scripts/uosc_shared/intl/es.json
+++ b/scripts/uosc_shared/intl/es.json
@@ -5,6 +5,7 @@
     "Audio devices": "Dispositivos de audio",
     "Audio tracks": "Pistas de audio",
     "Autoselect device": "Selección automática",
+    "Chapter %s": "Capítulo %s",
     "Chapters": "Capítulos",
     "Default": "Por defecto",
     "Default %s": "Por defecto %s",

--- a/scripts/uosc_shared/intl/fr.json
+++ b/scripts/uosc_shared/intl/fr.json
@@ -5,6 +5,7 @@
     "Audio devices": "Périphériques audio",
     "Audio tracks": "Pistes audio",
     "Autoselect device": "Sélection automatique",
+    "Chapter %s": "Chapitre %s",
     "Chapters": "Chapitres",
     "Default": "Par défaut",
     "Default %s": "Par défaut %s",

--- a/scripts/uosc_shared/intl/ro.json
+++ b/scripts/uosc_shared/intl/ro.json
@@ -5,6 +5,7 @@
     "Audio devices": "Dispozitive audio",
     "Audio tracks": "Piese audio",
     "Autoselect device": "Selectare automată",
+    "Chapter %s": "Capitolul %s",
     "Chapters": "Capitole",
     "Default": "Implicit",
     "Default %s": "Implicit %s",

--- a/scripts/uosc_shared/intl/zh-hans.json
+++ b/scripts/uosc_shared/intl/zh-hans.json
@@ -7,6 +7,7 @@
     "Audio devices": "音频设备",
     "Audio tracks": "音频轨道",
     "Autoselect device": "自动选择",
+    "Chapter %s": "第%s章",
     "Chapters": "章节",
     "Default": "默认",
     "Default %s": "默认 %s",

--- a/scripts/uosc_shared/lib/utils.lua
+++ b/scripts/uosc_shared/lib/utils.lua
@@ -539,7 +539,7 @@ function normalize_chapters(chapters)
 	table.sort(chapters, function(a, b) return a.time < b.time end)
 	-- Ensure titles
 	for index, chapter in ipairs(chapters) do
-		chapter.title = chapter.title or ('Chapter ' .. index)
+		chapter.title = chapter.title ~= '(unnamed)' and chapter.title ~= '' and chapter.title or t('Chapter %s', index)
 		chapter.lowercase_title = chapter.title:lower()
 	end
 	return chapters

--- a/scripts/uosc_shared/lib/utils.lua
+++ b/scripts/uosc_shared/lib/utils.lua
@@ -539,6 +539,10 @@ function normalize_chapters(chapters)
 	table.sort(chapters, function(a, b) return a.time < b.time end)
 	-- Ensure titles
 	for index, chapter in ipairs(chapters) do
+		local chapter_number = chapter.title and string.match(chapter.title, '^Chapter (%d+)$')
+		if chapter_number then
+			chapter.title = t('Chapter %s', tonumber(chapter_number))
+		end
 		chapter.title = chapter.title ~= '(unnamed)' and chapter.title ~= '' and chapter.title or t('Chapter %s', index)
 		chapter.lowercase_title = chapter.title:lower()
 	end


### PR DESCRIPTION
As well as handling of `(unnamed)` for mkv demuxer, empty string for disc demuxer.
https://github.com/mpv-player/mpv/blob/c5211dbf4ae38583b4a55ab63c5c07f8547f73b8/demux/demux_mkv.c#L964
https://github.com/mpv-player/mpv/blob/c5211dbf4ae38583b4a55ab63c5c07f8547f73b8/demux/demux_disc.c#L285
Other demuxers either don't supply a title, or use NULL as a fallback value.

Took care of German and Simplified Chinese too, since those have verified translations on Google.