### PR TITLE
feat: reintroduce lines chapter style

### DIFF
--- a/script-opts/uosc.conf
+++ b/script-opts/uosc.conf
@@ -22,8 +22,12 @@ timeline_opacity=0.9
 timeline_border=1
 # When scrolling above timeline, wheel will seek by this amount of seconds
 timeline_step=5
+# Timeline chapters style. available: never, diamonds, lines, lines-top, lines-bottom, lines-middle
+timeline_chapters=diamonds
 # Opacity of chapter indicators in timeline, 0 to disable
 timeline_chapters_opacity=0.8
+# Timeline chapter lines width
+timeline_chapters_width=4
 # Render cache indicators for streaming content
 timeline_cache=yes
 

--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -821,8 +821,18 @@ mp.observe_property('demuxer-cache-state', 'native', function(prop, cache_state)
 	table.sort(ranges, function(a, b) return a[1] < b[1] end)
 	if bof then ranges[1][1] = 0 end
 	if eof then ranges[#ranges][2] = state.duration end
+	filtered_cached_ranges = {}
+	local last_range = nil
+	for _, range in ipairs(ranges) do
+		if last_range and last_range[2] + 0.5 > range[1] then -- fuse ranges
+			last_range[2] = range[2]
+		elseif range[2] - range[1] > 0.5 then -- skip short ranges
+			filtered_cached_ranges[#filtered_cached_ranges + 1] = range
+			last_range = range
+		end
+	end
 
-	set_state('cached_ranges', ranges)
+	set_state('cached_ranges', filtered_cached_ranges)
 end)
 mp.observe_property('display-fps', 'native', observe_display_fps)
 mp.observe_property('estimated-display-fps', 'native', update_render_delay)

--- a/scripts/uosc_shared/elements/Timeline.lua
+++ b/scripts/uosc_shared/elements/Timeline.lua
@@ -234,7 +234,7 @@ function Timeline:render()
 		local ass_chapter_lines = assdraw.ass_new()
 		for i, chapter in ipairs(state.chapters) do
 			local x = t2x(chapter.time)
-			local ax, bx = round(x - chapter_half_width), round(x + chapter_half_width)
+			local ax, bx = round(x - chapter_half_width), math.min(round(x + chapter_half_width), bbx)
 			local ay, by = fay, fay + size
 			if chapter_gap_top then
 				ay = by - chapter_half_height
@@ -249,9 +249,9 @@ function Timeline:render()
 				ay, by = by, ay
 			end
 			ass_chapter_lines:rect_cw(ax, ay, bx, by, opts)
-			ass_erase_ranges:rect_cw(ax-1, ay-1, bx+1, by+1, opts)
+			ass_erase_ranges:rect_cw(ax - 1, ay - 1, bx + 1, by + 1, opts)
 		end
-		chapter_lines_clip = '\\clip(4,' .. ass_chapter_lines.text .. ')'
+		chapter_lines_clip = '\\clip(' .. ass_chapter_lines.scale .. ',' .. ass_chapter_lines.text .. ')'
 	end
 	if is_line then
 		ass_erase_ranges:rect_cw(fax, fay, fbx, fby)
@@ -275,8 +275,10 @@ function Timeline:render()
 			end
 		end
 		if options.timeline_cache then
-			cache_clip:rect_cw(0, 0, display.width, fay)
-			opts.clip = '\\iclip(4,' .. ass_erase_ranges.text .. ' ' .. cache_clip.text .. ')'
+			cache_clip:rect_cw(bax, 0, bbx, fay)       --hide top excess
+			cache_clip:rect_cw(0, 0, bax, fby)         --hide left excess
+			cache_clip:rect_cw(bbx, 0, bbx + bax, fby) --hide right excess
+			opts.clip = '\\iclip(' .. ass_erase_ranges.scale .. ',' .. ass_erase_ranges.text .. ' ' .. cache_clip.text .. ')'
 			opts.color, opts.opacity, opts.anchor_x = 'ffffff', 0.4 - (0.2 * visibility), bax
 			ass:texture(bax, fay, bbx, fby, texture_char, opts)
 			opts.color, opts.opacity, opts.anchor_x = '000000', 0.6 - (0.2 * visibility), bax + offset
@@ -289,7 +291,7 @@ function Timeline:render()
 		local rax = chapter_range.start < 0.1 and bax or t2x(chapter_range.start)
 		local rbx = chapter_range['end'] > state.duration - 0.1 and bbx
 			or t2x(math.min(chapter_range['end'], state.duration))
-		ass:rect(rax, fay, rbx, fby, {color = chapter_range.color, opacity = chapter_range.opacity, clip = '\\iclip(4,' .. ass_erase_ranges.text .. ')'})
+		ass:rect(rax, fay, rbx, fby, {color = chapter_range.color, opacity = chapter_range.opacity, clip = '\\iclip(' .. ass_erase_ranges.scale .. ',' .. ass_erase_ranges.text .. ')'})
 	end
 
 	-- Chapters


### PR DESCRIPTION
It had been removed in 3c85721f1ad24d030ff3f0a437aa6d5a254ff779 in favor of diamonds, for readability reasons with the introduction of uncached ranges.  
I never liked them, even if the chapter snapping feature is nice.

Overview of this new implementation of line chapters:
- Customizable chapter width
- Close-by chapters cannot produce ugly double-opacity overlaps
- Styles for full line, top, bottom, and a new option for middle (it came free with the implementation)
- Plays nice with cached ranges

Disregard the thumbnail spam, if it wasn't obvious that it's unrelated.  

![I'm Embarrassed For Her _watch?v=COALkXIzN3E_000558 658](https://user-images.githubusercontent.com/42466980/235405346-6b0439d2-638f-4318-91ee-809a473be555.png)

We no longer invert cached ranges.  
I've removed some of the cached ranges mangling (merging nearby ranges, skipping short ranges), it will have to be redone.  
Cached ranges no longer rely on tricky positioning based on font size. The texture is guaranteed to be continuous.