### PR TITLE
feat: scroll to new position after moving item in menu

### DIFF
--- a/scripts/uosc_shared/elements/Menu.lua
+++ b/scripts/uosc_shared/elements/Menu.lua
@@ -506,7 +506,7 @@ function Menu:move_selected_item_to(index)
 	if callback and from and from ~= index and index >= 1 and index <= #self.current.items then
 		callback(from, index, self.current.submenu_path)
 		self.current.selected_index = index
-		request_render()
+		self:set_scroll_by((index - from) * self.scroll_step)
 	end
 end
 


### PR DESCRIPTION
When moving around items the scroll position doesn't update, which can be annoying when moving things around in a large playlist. Instead the menu should scroll with the moved item.

The problem with this is that scrolling itself causes a render, which means the menu gets rendered once with the updated scroll position but with the playlist item still in it's old position, and then again when the playlist itself gets updated, leading to a short visual artifact.

I can't think of a good solution to this.
It's possible to stop scrolling from requesting renders and instead request renders in other places instead, but that would still lead to problems when something else (e.g. playback position update) causes a render.
It's also possible to preemptively move the menu item in the menu itself, but then if the underlying data doesn't change for whatever reason there is a disconnect between what the menu shows and what's actually there.
