### PR TITLE
fix: take window_border_size into account for tooltip positioning

### DIFF
--- a/scripts/uosc_shared/lib/ass.lua
+++ b/scripts/uosc_shared/lib/ass.lua
@@ -85,7 +85,7 @@ function ass_mt:tooltip(element, value, opts)
 	local align_top = opts.responsive == false or element.ay - offset > opts.size * 2
 	local x = element.ax + (element.bx - element.ax) / 2
 	local y = align_top and element.ay - offset or element.by + offset
-	local margin = (opts.width_overwrite or text_width(value, opts)) / 2 + 10
+	local margin = (opts.width_overwrite or text_width(value, opts)) / 2 + 10 + Elements.window_border.size
 	self:txt(clamp(margin, x, display.width - margin), y, align_top and 2 or 8, value, opts)
 end
 


### PR DESCRIPTION
(Disregard the overextended timeline)
![Afternoon Pulp  Discover the 8 Man Dance!  0B9A8C31 -meme mkv_000001 502](https://user-images.githubusercontent.com/42466980/236237401-b9e3140b-f0e4-4202-ae4d-767bbb9027c0.png)
![Afternoon Pulp  Discover the 8 Man Dance!  0B9A8C31 -meme mkv_000001 535](https://user-images.githubusercontent.com/42466980/236237420-9db94fe6-ddf4-4ce1-9251-cd3d077ee794.png)
