### PR TITLE
feat: `get_locale` api for scripts localization

### DIFF
--- a/scripts/uosc.lua
+++ b/scripts/uosc.lua
@@ -1257,7 +1257,11 @@ mp.register_script_message('set-min-visibility', function(visibility, elements)
 end)
 mp.register_script_message('flash-elements', function(elements) Elements:flash(split(elements, ' *, *')) end)
 mp.register_script_message('overwrite-binding', function(name, command) key_binding_overwrites[name] = command end)
-mp.register_script_message('add-intl-directory', function(path) intl.add_directory(path) end)
+mp.register_script_message('get-locale', function(script, path)
+	local locale = intl.get_locale(path)
+	local json = utils.format_json(locale)
+	mp.commandv('script-message-to', script, 'uosc-locale', json)
+end)
 
 --[[ ELEMENTS ]]
 


### PR DESCRIPTION
and deprecates `add-intl-directory`.

Since https://github.com/tomasklaen/uosc/issues/538 `add-intl-directory` no longer works as expected. Also `get_locale` avoids pollution between multiple translation sources.

Use example: https://github.com/natural-harmonia-gropius/mpv-config/pull/23/files

---

I'll update readme later if you feel ok with this.
