### PR TITLE
fix: crash when opening a non blurred menu

### DIFF
--- a/scripts/uosc_shared/elements/Menu.lua
+++ b/scripts/uosc_shared/elements/Menu.lua
@@ -271,7 +271,7 @@ function Menu:reset_navigation()
 	if self.mouse_nav then
 		self:select_item_below_cursor()
 	elseif menu.items and #menu.items > 0 then
-		self:select_index(itable_find(menu.items, function(item) return item.selectable ~= false end))
+		self:select_index(itable_find(menu.items, function(item) return item.selectable ~= false end), menu)
 	else
 		self:select_index(nil)
 	end


### PR DESCRIPTION
`itable_find()` returns two values, so without specifying the second parameter to `select_index()` lua will use the second return value for that.

Closes #564