### PR TITLE
feat: initial support for updating options at runtime

### DIFF
--- a/scripts/uosc/elements/Controls.lua
+++ b/scripts/uosc/elements/Controls.lua
@@ -19,6 +19,10 @@ function Controls:init()
 	---@type ControlItem[] Only controls that match current dispositions.
 	self.layout = {}
 
+	self:init_options()
+end
+
+function Controls:init_options()
 	-- Serialize control elements
 	local shorthands = {
 		menu = 'command:menu:script-binding uosc/menu-blurred?Menu',
@@ -325,5 +329,12 @@ function Controls:on_display() self:update_dimensions() end
 function Controls:on_prop_border() self:update_dimensions() end
 function Controls:on_prop_fullormaxed() self:update_dimensions() end
 function Controls:on_timeline_enabled() self:update_dimensions() end
+
+function Controls:on_options()
+	for _, control in ipairs(self.controls) do
+		if control.element then control.element:destroy() end
+	end
+	self:init_options()
+end
 
 return Controls

--- a/scripts/uosc/elements/Element.lua
+++ b/scripts/uosc/elements/Element.lua
@@ -146,6 +146,7 @@ function Element:flash()
 		self:tween_stop()
 		self.forced_visibility = 1
 		request_render()
+		self._flash_out_timer.timeout = options.flash_duration / 1000
 		self._flash_out_timer:kill()
 		self._flash_out_timer:resume()
 	end

--- a/scripts/uosc/elements/Menu.lua
+++ b/scripts/uosc/elements/Menu.lua
@@ -541,6 +541,7 @@ end
 
 function Menu:on_display() self:update_dimensions() end
 function Menu:on_prop_fullormaxed() self:update_content_dimensions() end
+function Menu:on_options() self:update_content_dimensions() end
 
 function Menu:handle_cursor_down()
 	if self.proximity_raw == 0 then

--- a/scripts/uosc/elements/Speed.lua
+++ b/scripts/uosc/elements/Speed.lua
@@ -27,6 +27,7 @@ function Speed:on_coordinates()
 	self.notch_spacing = self.width / (self.notches + 1)
 	self.font_size = round(self.height * 0.48 * options.font_scale)
 end
+function Speed:on_options() self:on_coordinates() end
 
 function Speed:speed_step(speed, up)
 	if options.speed_step_is_factor then

--- a/scripts/uosc/elements/Timeline.lua
+++ b/scripts/uosc/elements/Timeline.lua
@@ -108,6 +108,10 @@ function Timeline:on_prop_time() self:decide_enabled() end
 function Timeline:on_prop_border() self:update_dimensions() end
 function Timeline:on_prop_fullormaxed() self:update_dimensions() end
 function Timeline:on_display() self:update_dimensions() end
+function Timeline:on_options()
+	self.top_border = options.timeline_border
+	self:update_dimensions()
+end
 function Timeline:handle_cursor_up()
 	if self.pressed then
 		mp.set_property_native('pause', self.pressed.pause)

--- a/scripts/uosc/elements/TopBar.lua
+++ b/scripts/uosc/elements/TopBar.lua
@@ -156,6 +156,11 @@ end
 
 function TopBar:on_display() self:update_dimensions() end
 
+function TopBar:on_options()
+	self:decide_enabled()
+	self:update_dimensions()
+end
+
 function TopBar:render()
 	local visibility = self:get_visibility()
 	if visibility <= 0 then return end

--- a/scripts/uosc/elements/Volume.lua
+++ b/scripts/uosc/elements/Volume.lua
@@ -248,5 +248,6 @@ end
 function Volume:on_display() self:update_dimensions() end
 function Volume:on_prop_border() self:update_dimensions() end
 function Volume:on_controls_reflow() self:update_dimensions() end
+function Volume:on_options() self:update_dimensions() end
 
 return Volume

--- a/scripts/uosc/elements/WindowBorder.lua
+++ b/scripts/uosc/elements/WindowBorder.lua
@@ -17,6 +17,7 @@ end
 
 function WindowBorder:on_prop_border() self:decide_enabled() end
 function WindowBorder:on_prop_fullormaxed() self:decide_enabled() end
+function WindowBorder:on_options() self:decide_enabled() end
 
 function WindowBorder:render()
 	if self.size > 0 then

--- a/scripts/uosc/main.lua
+++ b/scripts/uosc/main.lua
@@ -109,7 +109,12 @@ defaults = {
 	languages = 'slang,en',
 }
 options = table_shallow_copy(defaults)
-opt.read_options(options, 'uosc')
+opt.read_options(options, 'uosc', function(_)
+	update_human_times()
+	Elements:trigger('options')
+	Elements:update_proximities()
+	request_render()
+end)
 -- Normalize values
 options.proximity_out = math.max(options.proximity_out, options.proximity_in + 1)
 if options.chapter_ranges:sub(1, 4) == '^op|' then options.chapter_ranges = defaults.chapter_ranges end


### PR DESCRIPTION
Options can be changed during runtime by changing `script-opts`.
So far such option changes were simply ignored, but basic support for some options is very easy to achieve.

This is a very half baked thing, so far only `time_precision` and `font_scale` have been tested. Options that are as trivial to update as `font_scale` should also work without a problem, but other options need some additional work (similar to `time_precision`).
Also changes to e.g. `proximity_out` don't execute the same sanity checking as it does during initialization. We could move all the initialization stuff into a function that then gets executed in the update callback, which is trivial for the sanity checking, but requires some more work for the `config` table. Opinions?