### PR TITLE
fix: crash when a script menu update renders selected index unavailable

### DIFF
--- a/scripts/uosc/elements/Menu.lua
+++ b/scripts/uosc/elements/Menu.lua
@@ -186,6 +186,10 @@ function Menu:update(data)
 		local old_menu = self.by_id[menu.is_root and '__root__' or menu.id]
 		if old_menu then table_assign(menu, old_menu, {'selected_index', 'scroll_y', 'fling'}) end
 
+		if menu.selected_index then
+			menu.selected_index = #menu.items > 0 and clamp(1, menu.selected_index, #menu.items) or nil
+		end
+
 		new_all[#new_all + 1] = menu
 		new_by_id[menu.is_root and '__root__' or menu.id] = menu
 	end


### PR DESCRIPTION
When a script-defined menu gets updated with fewer items than it previously had, the user's selected index doesn't get clamped or reset, leading to this crash when pressing Enter:
```lua
[uosc] 
[uosc] stack traceback:
[uosc]  /home/eva/.config/mpv/scripts/uosc/elements/Menu.lua:499: in function 'open_selected_item'
[uosc]  /home/eva/.config/mpv/scripts/uosc/elements/Menu.lua:514: in function </home/eva/.config/mpv/scripts/uosc/elements/Menu.lua:514>
[uosc]  (...tail calls...)
[uosc]  /home/eva/.config/mpv/scripts/uosc/elements/Menu.lua:678: in function 'fn'
[uosc]  mp.defaults:230: in function 'fn'
[uosc]  mp.defaults:65: in function 'handler'
[uosc]  mp.defaults:380: in function 'handler'
[uosc]  mp.defaults:510: in function 'call_event_handlers'
[uosc]  mp.defaults:552: in function 'dispatch_events'
[uosc]  mp.defaults:503: in function <mp.defaults:502>
[uosc]  [C]: in ?
[uosc]  [C]: in ?
[uosc] Lua error: /home/eva/.config/mpv/scripts/uosc/elements/Menu.lua:499: attempt to index local 'item' (a nil value)
```
I'm not sure if `Menu:update_dimensions()` is the proper place to update the selected index, but it fixes the issue.  
Ran into this with [memo](https://github.com/po5/memo), switching from the 2nd page of results back to the first, if you need a real example of it.