### PR TITLE
feat: add a background to timeline tooltips

### DIFF
--- a/scripts/uosc/lib/ass.lua
+++ b/scripts/uosc/lib/ass.lua
@@ -75,18 +75,32 @@ end
 -- Tooltip.
 ---@param element {ax: number; ay: number; bx: number; by: number}
 ---@param value string|number
----@param opts? {size?: number; offset?: number; bold?: boolean; italic?: boolean; width_overwrite?: number, responsive?: boolean}
+---@param opts? {size?: number; offset?: number; bold?: boolean; italic?: boolean; width_overwrite?: number, margin?: number, responsive?: boolean, opacity?: number, lines?: integer}
 function ass_mt:tooltip(element, value, opts)
+	if value == '' then return end
 	opts = opts or {}
 	opts.size = opts.size or 16
 	opts.border = options.text_border
 	opts.border_color = bg
-	local offset = opts.offset or opts.size / 2
+	opts.margin = opts.margin or 10
+	opts.opacity = opts.opacity or options.timeline_opacity
+	opts.lines = opts.lines or 1
+	local padding_y = round(opts.size / 6)
+	local padding_x = round(opts.size / 3)
+	local offset = opts.offset or 2
 	local align_top = opts.responsive == false or element.ay - offset > opts.size * 2
 	local x = element.ax + (element.bx - element.ax) / 2
 	local y = align_top and element.ay - offset or element.by + offset
-	local margin = (opts.width_overwrite or text_width(value, opts)) / 2 + 10 + Elements.window_border.size
-	self:txt(clamp(margin, x, display.width - margin), y, align_top and 2 or 8, value, opts)
+	local width_half = (opts.width_overwrite or text_width(value, opts)) / 2 + padding_x
+	local min_edge_distance = width_half + opts.margin + Elements.window_border.size
+	x = clamp(min_edge_distance, x, display.width - min_edge_distance)
+	local ax, bx = x - width_half, x + width_half
+	local ay = (align_top and y - opts.size * opts.lines - 2 * padding_y or y)
+	local by = (align_top and y or y + opts.size * opts.lines + 2 * padding_y)
+	self:rect(ax, ay, bx, by, {color = bg, opacity = opts.opacity, radius = 2})
+	opts.opacity = nil
+	self:txt(x, align_top and y - padding_y or y + padding_y, align_top and 2 or 8, value, opts)
+	return { ax = element.ax, ay = ay, bx = element.bx, by = by }
 end
 
 -- Rectangle.

--- a/scripts/uosc/lib/text.lua
+++ b/scripts/uosc/lib/text.lua
@@ -400,14 +400,14 @@ end
 ---@param text string
 ---@param opts {size: number; bold?: boolean; italic?: boolean}
 ---@param target_line_length number
----@return string
+---@return string, integer
 function wrap_text(text, opts, target_line_length)
 	local target_line_width = target_line_length * width_length_ratio * opts.size
 	local bold, scale_factor, scale_offset = opts.bold or false, opts_factor_offset(opts)
 	local wrap_at_chars = {' ', '　', '-', '–'}
 	local remove_when_wrap = {' ', '　'}
 	local lines = {}
-	for text_line in text:gmatch("([^\n]*)\n?") do
+	for _, text_line in ipairs(split(text, '\n')) do
 		local line_width = scale_offset
 		local line_start = 1
 		local before_end = nil
@@ -458,5 +458,5 @@ function wrap_text(text, opts, target_line_length)
 		if #text_line >= line_start then lines[#lines + 1] = text_line:sub(line_start)
 		elseif text_line == '' then lines[#lines + 1] = '' end
 	end
-	return table.concat(lines, '\n')
+	return table.concat(lines, '\n'), #lines
 end

--- a/scripts/uosc/lib/utils.lua
+++ b/scripts/uosc/lib/utils.lua
@@ -610,7 +610,7 @@ function serialize_chapters(chapters)
 	local opts = {size = 1, bold = true}
 	for index, chapter in ipairs(chapters) do
 		chapter.index = index
-		chapter.title_wrapped = wrap_text(chapter.title, opts, 25)
+		chapter.title_wrapped, chapter.title_lines = wrap_text(chapter.title, opts, 25)
 		chapter.title_wrapped_width = text_width(chapter.title_wrapped, opts)
 		chapter.title_wrapped = ass_escape(chapter.title_wrapped)
 	end


### PR DESCRIPTION
Depending on the current frame of the video the hovered time and chapter title might be hard to read.

Do we even want something like this?

And if so, how big should the background margins be? Should they be adjusted to always line up with the background of the other ones, like is the case in the screenshot?
Currently it's based on font size, but of course that doesn't necessarily line up neatly with the other backgrounds, and it uses the timeline opacity (0.7 in the screenshot).

I didn't have a good sample on hand, but here is what it currently looks like.
![image](https://github.com/tomasklaen/uosc/assets/8932183/3b601c2b-8936-415e-8946-ef73c816c6db)

P.S. I had to change the line splitting in the wrap_text() because otherwise it always added an additional empty line at the end, which led to the wrong line count.