### PR TITLE
feat: make the menu searchable

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,7 +421,9 @@ Menu {
   items: Item[];
   selected_index?: integer;
   keep_open?: boolean;
-  on_close: string | string[];
+  on_close?: string | string[];
+  on_search?: string | string[];
+  search_debounce?: string | number;
 }
 
 Item = Command | Submenu;
@@ -431,6 +433,8 @@ Submenu {
   hint?: string;
   items: Item[];
   keep_open?: boolean;
+  on_search?: string | string[];
+  search_debounce?: string | number;
 }
 
 Command {
@@ -448,9 +452,11 @@ Command {
 }
 ```
 
-When `Command.value` is a string, it'll be passed to `mp.command(value)`. If it's a table (array) of strings, it'll be used as `mp.commandv(table.unpack(value))`. The same goes for `Menu.on_close`.
+When `Command.value` is a string, it'll be passed to `mp.command(value)`. If it's a table (array) of strings, it'll be used as `mp.commandv(table.unpack(value))`. The same goes for `Menu.on_close` and `on_search`. `on_search` additionally appends the current search string as the last parameter.
 
 `Menu.type` controls what happens when opening a menu when some other menu is already open. When the new menu type is different, it'll replace the currently opened menu. When it's the same, the currently open menu will simply be closed. This is used to implement toggling of menus with the same type.
+
+`search_debounce` controls how soon the search happens after the last character was entered in milliseconds. Entering new character resets the timer. Defaults to 300. It can also have a special value `submit`, which triggers a search only after `ctrl+enter` was pressed.
 
 `item.icon` property accepts icon names. You can pick one from here: [Google Material Icons](https://fonts.google.com/icons?selected=Material+Icons)\
 There is also a special icon name `spinner` which will display a rotating spinner. Along with a no-op command on an item and `keep_open=true`, this can be used to display placeholder menus/items that are still loading.

--- a/script-opts/uosc.conf
+++ b/script-opts/uosc.conf
@@ -115,6 +115,10 @@ menu_min_width=260
 menu_min_width_fullscreen=360
 menu_opacity=1
 menu_parent_opacity=0.4
+# Determines if `/` or `ctrl+f` is required to activate the search, or if typing
+# any text is sufficient.
+# When enabled, you can no longer toggle a menu off with the same key that opened it, if the key is a unicode character.
+menu_type_to_search=yes
 
 # Top bar with window controls and media title
 # Can be: never, no-border, always

--- a/scripts/uosc/elements/Menu.lua
+++ b/scripts/uosc/elements/Menu.lua
@@ -261,7 +261,7 @@ function Menu:update_dimensions()
 	for _, menu in ipairs(self.all) do
 		local width = math.max(menu.search and menu.search.width or 0, menu.max_width)
 		menu.width = round(clamp(min_width, width, display.width * 0.9))
-		local title_height = (menu.is_root and menu.title) and self.scroll_step or 0
+		local title_height = (menu.is_root and menu.title or menu.search) and self.scroll_step or 0
 		local max_height = round(height_available * 0.9 - title_height)
 		local content_height = self.scroll_step * #menu.items
 		menu.height = math.min(content_height - self.item_spacing, max_height)
@@ -886,7 +886,7 @@ function Menu:render()
 		local is_current, is_parent, is_submenu = pos == 0, pos < 0, pos > 0
 		local menu_opacity = pos == 0 and opacity or opacity * (options.menu_parent_opacity ^ math.abs(pos))
 		local ax, ay, bx, by = x, menu.top, x + menu.width, menu.top + menu.height
-		local draw_title = menu.is_root and menu.title
+		local draw_title = menu.is_root and menu.title or menu.search
 		local scroll_clip = '\\clip(0,' .. ay .. ',' .. display.width .. ',' .. by .. ')'
 		local start_index = math.floor(menu.scroll_y / self.scroll_step) + 1
 		local end_index = math.ceil((menu.scroll_y + menu.height) / self.scroll_step)
@@ -1027,7 +1027,6 @@ function Menu:render()
 		if draw_title then
 			local title_ay = ay - self.item_height
 			local title_height = self.item_height - 3
-			menu.ass_safe_title = menu.ass_safe_title or ass_escape(menu.title)
 
 			-- Background
 			ass:rect(ax + 2, title_ay, bx - 2, title_ay + title_height, {
@@ -1044,6 +1043,7 @@ function Menu:render()
 					clip = '\\clip(' .. ax + 2 .. ',' .. title_ay .. ',' .. bx - 2 .. ',' .. ay .. ')',
 				})
 			else
+				menu.ass_safe_title = menu.ass_safe_title or ass_escape(menu.title)
 				ass:txt(ax + menu.width / 2, title_ay + (title_height / 2), 5, menu.ass_safe_title, {
 					size = self.font_size, bold = true, color = bg, wrap = 2, opacity = menu_opacity,
 					clip = '\\clip(' .. ax + 2 .. ',' .. title_ay .. ',' .. bx - 2 .. ',' .. ay .. ')',

--- a/scripts/uosc/elements/Menu.lua
+++ b/scripts/uosc/elements/Menu.lua
@@ -1065,19 +1065,36 @@ function Menu:render()
 			local title_height = self.item_height - 3
 
 			-- Background
-			ass:rect(ax + 2, title_ay, bx - 2, title_ay + title_height, {
-				color = fg, opacity = menu_opacity * 0.8, radius = 2,
-			})
-			ass:texture(ax + 2, title_ay, bx - 2, title_ay + title_height, 'n', {
-				size = 80, color = bg, opacity = menu_opacity * 0.1,
-			})
+			if menu.search then
+				ass:rect(ax + 3, title_ay + 1, bx - 3, title_ay + title_height - 1, {
+					color = fg .. '\\1a&HFF', opacity = menu_opacity * 0.1, radius = 2,
+					border = 1, border_color = fg, border_opacity = menu_opacity * 0.8
+				})
+				ass:texture(ax + 3, title_ay + 1, bx - 3, title_ay + title_height - 1, 'n', {
+					size = 80, color = bg, opacity = menu_opacity * 0.1, anchor_x = ax + 2, anchor_y = title_ay,
+				})
+			else
+				ass:rect(ax + 2, title_ay, bx - 2, title_ay + title_height, {
+					color = fg, opacity = menu_opacity * 0.8, radius = 2,
+				})
+				ass:texture(ax + 2, title_ay, bx - 2, title_ay + title_height, 'n', {
+					size = 80, color = bg, opacity = menu_opacity * 0.1,
+				})
+			end
 
 			-- Title
 			if menu.search then
-				ass:txt(bx - 4, title_ay + (title_height / 2), 6, ass_escape(menu.search.query), {
-					size = self.font_size, color = bg, wrap = 2, opacity = menu_opacity,
-					clip = '\\clip(' .. ax + 2 .. ',' .. title_ay .. ',' .. bx - 2 .. ',' .. ay .. ')',
-				})
+				if menu.search.query ~= '' then
+					ass:txt(bx - spacing, title_ay + (title_height / 2), 6, ass_escape(menu.search.query), {
+						size = self.font_size, color = bgt, wrap = 2, opacity = menu_opacity,
+						clip = '\\clip(' .. ax + spacing .. ',' .. title_ay .. ',' .. bx - spacing .. ',' .. ay .. ')',
+					})
+				else
+					ass:txt(bx - spacing, title_ay + (title_height / 2), 6, 'search for...', {
+						size = self.font_size, italic = true, color = bgt, wrap = 2, opacity = menu_opacity * 0.5,
+						clip = '\\clip(' .. ax + spacing .. ',' .. title_ay .. ',' .. bx - spacing .. ',' .. ay .. ')',
+					})
+				end
 			else
 				menu.ass_safe_title = menu.ass_safe_title or ass_escape(menu.title)
 				ass:txt(ax + menu.width / 2, title_ay + (title_height / 2), 5, menu.ass_safe_title, {

--- a/scripts/uosc/elements/Menu.lua
+++ b/scripts/uosc/elements/Menu.lua
@@ -11,7 +11,7 @@ local Element = require('elements/Element')
 ---@alias MenuStackItem MenuStackValue|MenuStack
 ---@alias MenuStackValue {title?: string; hint?: string; icon?: string; value: any; active?: boolean; bold?: boolean; italic?: boolean; muted?: boolean; keep_open?: boolean; separator?: boolean; selectable?: boolean; align?: 'left'|'center'|'right'; title_width: number; hint_width: number}
 ---@alias Fling {y: number, distance: number, time: number, easing: fun(x: number), duration: number, update_cursor?: boolean}
----@alias Search {query: string; timeout: unknown; source: {scroll_y: number; selected_index?: integer; items?: MenuDataItem[]}}
+---@alias Search {query: string; timeout: unknown; width: number; top: number; source: {scroll_y: number; selected_index?: integer; items?: MenuDataItem[]}}
 
 ---@alias Modifiers {shift?: boolean, ctrl?: boolean, alt?: boolean}
 ---@alias MenuCallbackMeta {modifiers: Modifiers}
@@ -259,12 +259,14 @@ function Menu:update_dimensions()
 	local height_available = display.height - Elements.timeline.size_min
 
 	for _, menu in ipairs(self.all) do
-		menu.width = round(clamp(min_width, menu.max_width, display.width * 0.9))
+		local width = math.max(menu.search and menu.search.width or 0, menu.max_width)
+		menu.width = round(clamp(min_width, width, display.width * 0.9))
 		local title_height = (menu.is_root and menu.title) and self.scroll_step or 0
 		local max_height = round(height_available * 0.9 - title_height)
 		local content_height = self.scroll_step * #menu.items
 		menu.height = math.min(content_height - self.item_spacing, max_height)
-		menu.top = round((height_available - menu.height + title_height) / 2)
+		local search_top = menu.search and menu.search.top or height_available
+		menu.top = math.min(search_top, round((height_available - menu.height + title_height) / 2))
 		menu.scroll_height = math.max(content_height - menu.height - self.item_spacing, 0)
 		menu.scroll_y = menu.scroll_y or 0
 		self:scroll_to(menu.scroll_y, menu) -- clamps scroll_y to scroll limits
@@ -739,7 +741,7 @@ function Menu:search_start()
 		end))
 	end
 	menu.search = {
-		query = '', timeout = timeout,
+		query = '', timeout = timeout, width = menu.width, top = menu.top,
 		source = {
 			scroll_y = menu.scroll_y, selected_index = menu.selected_index,
 			items = not menu.on_search and menu.items or nil

--- a/scripts/uosc/main.lua
+++ b/scripts/uosc/main.lua
@@ -56,6 +56,7 @@ defaults = {
 	menu_min_width_fullscreen = 360,
 	menu_opacity = 1,
 	menu_parent_opacity = 0.4,
+	menu_type_to_search = true,
 
 	top_bar = 'no-border',
 	top_bar_size = 40,


### PR DESCRIPTION
A search can be started with `ctrl+f` or `/` and stopped with `esc`.

It currently works for anything using `create_self_updating_menu_opener()`, `open_file_navigation_menu()` and menus opened by scripts.
Internal menus do a case insensitive search of the title and hint, while scripts have to do their own filtering.
The reason why scripts have to do their own filtering is because that allows scripts like [memo](https://github.com/po5/memo) to do proper filtering despite splitting up the results in pages.

I've use a little bit of code from console.lua ([1](https://github.com/mpv-player/mpv/blob/3972fd1be4ef0f8fe083b43e41c3e06104003a3c/player/lua/console.lua#L258-L260) [2](https://github.com/mpv-player/mpv/blob/3972fd1be4ef0f8fe083b43e41c3e06104003a3c/player/lua/console.lua#L769-L770)), but I got permission from the original author.

