### PR TITLE
fix: crash when selecting "Empty" in chapters menu

### DIFF
--- a/scripts/uosc/elements/Menu.lua
+++ b/scripts/uosc/elements/Menu.lua
@@ -753,7 +753,7 @@ function Menu:render()
 			local is_selected = menu.selected_index == index or item.active
 
 			-- Select hovered item
-			if is_current and self.mouse_nav then
+			if is_current and self.mouse_nav and item.selectable ~= false then
 				if submenu_rect and cursor.direction_to_rectangle_distance(submenu_rect) then
 					blur_selected_index = false
 				else


### PR DESCRIPTION
The menu item representing an empty menu is supposed to be not selectable, however it was possible to select it with the mouse. That results in a crash in the chapters menu because it subtracts one from the value, which is "ignore" for the "Empty" item.