### PR TITLE
fix: shuffle history couldn't go back more than once

### DIFF
--- a/scripts/uosc/lib/utils.lua
+++ b/scripts/uosc/lib/utils.lua
@@ -394,9 +394,10 @@ end
 -- randomness to determine the next item. Loops around if `loop-playlist` is enabled.
 ---@param paths table
 ---@param current_index number
----@param delta number
+---@param delta number 1 or -1 for forward or backward
 function decide_navigation_in_list(paths, current_index, delta)
 	if #paths < 2 then return #paths, paths[#paths] end
+	delta = delta < 0 and -1 or 1
 
 	-- Shuffle looks at the played files history trimmed to 80% length of the paths
 	-- and removes all paths in it from the potential shuffle pool. This guarantees

--- a/scripts/uosc/lib/utils.lua
+++ b/scripts/uosc/lib/utils.lua
@@ -462,12 +462,9 @@ function navigate_playlist(delta)
 	local playlist, pos = mp.get_property_native('playlist'), mp.get_property_native('playlist-pos-1')
 	if playlist and #playlist > 1 and pos then
 		local paths = itable_map(playlist, function(item) return normalize_path(item.filename) end)
-		local index, path = decide_navigation_in_list(paths, pos, delta)
+		local index = decide_navigation_in_list(paths, pos, delta)
 		if index then
 			mp.commandv('playlist-play-index', index - 1)
-			return true
-		elseif path then
-			mp.commandv('loadfile', path)
 			return true
 		end
 	end

--- a/scripts/uosc/lib/utils.lua
+++ b/scripts/uosc/lib/utils.lua
@@ -407,13 +407,15 @@ function decide_navigation_in_list(paths, current_index, delta)
 			paths = itable_slice(state.history)
 		}
 		state.shuffle_history.pos = state.shuffle_history.pos + delta
-		if state.shuffle_history.pos < 1 or state.shuffle_history.pos > #state.shuffle_history.paths + 1 then
-			state.shuffle_history.pos = clamp(1, state.shuffle_history.pos, #state.shuffle_history.paths + 1)
+		local history_path = state.shuffle_history.paths[state.shuffle_history.pos]
+		local next_index = history_path and itable_index_of(paths, history_path)
+		if next_index then
+			return next_index, history_path
+		end
+		if delta < 0 then
+			state.shuffle_history.pos = state.shuffle_history.pos - delta
 		else
-			local history_path = state.shuffle_history.paths[state.shuffle_history.pos]
-			if history_path then
-				return itable_index_of(paths, history_path), history_path
-			end
+			state.shuffle_history.pos = math.min(state.shuffle_history.pos, #state.shuffle_history.paths + 1)
 		end
 
 		local trimmed_history = itable_slice(state.history, -math.floor(#paths * 0.8))

--- a/scripts/uosc/main.lua
+++ b/scripts/uosc/main.lua
@@ -481,6 +481,9 @@ state = {
 	has_chapter = false,
 	has_playlist = false,
 	shuffle = options.shuffle,
+	---@type nil|{pos: number; paths: string[]}
+	shuffle_history = nil,
+	on_shuffle = function() state.shuffle_history = nil end,
 	mouse_bindings_enabled = false,
 	uncached_ranges = nil,
 	cache = nil,
@@ -607,6 +610,7 @@ end
 
 function set_state(name, value)
 	state[name] = value
+	call_maybe(state['on_' .. name], value)
 	Elements:trigger('prop_' .. name, value)
 end
 


### PR DESCRIPTION
Shuffle now has its own history which inherits from `state.history` to not break the prev button.

It can populate the history with random items in both directions.

When shuffle is disabled, it clears its history (so all next states if any), but next time it's enabled it'll inherit `state.history` for its prev states again.

Did I miss anything?

ref #635