### PR TITLE
fix: case insensitive menu search

### DIFF
--- a/scripts/uosc/elements/Menu.lua
+++ b/scripts/uosc/elements/Menu.lua
@@ -647,7 +647,7 @@ end
 
 ---@param menu MenuStack
 function Menu:search_internal(menu)
-	local query = menu.search.query
+	local query = menu.search.query:lower()
 	menu.items = query ~= '' and itable_filter(menu.search.source.items, function(item)
 		return item.title and item.title:lower():find(query, 1, true) or
 			item.hint and item.hint:lower():find(query, 1, true)


### PR DESCRIPTION
The title was lowered, but not the query.
As a result searching for uppercase letters would never match anything.

Fixes #637

I must have accidentally done one too many undo or something, after all the whole point of making it into a local variable was for the lowering...