### PR TITLE
fix: prepare for shared-script-properties removal

### DIFF
--- a/scripts/uosc/main.lua
+++ b/scripts/uosc/main.lua
@@ -589,7 +589,9 @@ function update_margins()
 	state.margin_left = left
 	state.margin_right = right
 
-	utils.shared_script_property_set('osc-margins', string.format('%f,%f,%f,%f', 0, 0, top, bottom))
+	if utils.shared_script_property_set then
+		utils.shared_script_property_set('osc-margins', string.format('%f,%f,%f,%f', 0, 0, top, bottom))
+	end
 	mp.set_property_native('user-data/osc/margins', { l = left, r = right, t = top, b = bottom })
 
 	if not options.adjust_osd_margins then return end


### PR DESCRIPTION
mpv is about to remove `shared-script-properties`, which will cause `utils.shared_script_property_set` to be nil.
Check for it's existence before calling it.
https://github.com/mpv-player/mpv/pull/12456

Whenever our latest supported version is after 36.0 we can drop that call altogether.