### PR TITLE
fix: stream quality selection

### DIFF
--- a/scripts/uosc/main.lua
+++ b/scripts/uosc/main.lua
@@ -1082,12 +1082,10 @@ bind_command('stream-quality', function()
 		-- Reload the video to apply new format
 		-- This is taken from https://github.com/jgreco/mpv-youtube-quality
 		-- which is in turn taken from https://github.com/4e6/mpv-reload/
-		-- Dunno if playlist_pos shenanigans below are necessary.
-		local playlist_pos = mp.get_property_number('playlist-pos')
 		local duration = mp.get_property_native('duration')
 		local time_pos = mp.get_property('time-pos')
 
-		mp.set_property_number('playlist-pos', playlist_pos)
+		mp.command('playlist-play-index current')
 
 		-- Tries to determine live stream vs. pre-recorded VOD. VOD has non-zero
 		-- duration property. When reloading VOD, to keep the current time position


### PR DESCRIPTION
Due to a recent change in mpv writing to `playlist-pos` doesn't restart playback anymore, which was necessary for the format change to work for the current file.
https://github.com/mpv-player/mpv/commit/4b2276b730c8542649b665aaec187e1c7e3b2612