### PR TITLE
feat: search first character of each word

### DIFF
--- a/scripts/uosc/elements/Menu.lua
+++ b/scripts/uosc/elements/Menu.lua
@@ -649,8 +649,11 @@ end
 function Menu:search_internal(menu)
 	local query = menu.search.query:lower()
 	menu.items = query ~= '' and itable_filter(menu.search.source.items, function(item)
-		return item.title and item.title:lower():find(query, 1, true) or
-			item.hint and item.hint:lower():find(query, 1, true)
+		local title = item.title and item.title:lower()
+		local hint = item.hint and item.hint:lower()
+		return title and title:find(query, 1, true) or hint and hint:find(query, 1, true) or
+			title and table.concat(first_word_chars(title)):find(query, 1, true) or
+			hint and table.concat(first_word_chars(hint)):find(query, 1, true)
 	end) or menu.search.source.items
 	self:search_update_items()
 end

--- a/scripts/uosc/lib/text.lua
+++ b/scripts/uosc/lib/text.lua
@@ -460,3 +460,25 @@ function wrap_text(text, opts, target_line_length)
 	end
 	return table.concat(lines, '\n'), #lines
 end
+
+do
+	local word_separators = {
+		' ', '　', '\t', '-', '–', '_', ',', '.', '+', '&', '(', ')', '[', ']', '{', '}', '<', '>', '/', '\\',
+	}
+
+	---Get the first character of each words
+	---@param str string
+	---@return string[]
+	function first_word_chars(str)
+		local first_chars, is_word_start, word_separators = {}, true, word_separators
+		for _, char in utf8_iter(str) do
+			if itable_has(word_separators, char) then
+				is_word_start = true
+			elseif is_word_start then
+				first_chars[#first_chars + 1] = char
+				is_word_start = false
+			end
+		end
+		return first_chars
+	end
+end


### PR DESCRIPTION
I don't really understand why title and hint characters should be concatenated.
It might make some sense when the title is only one word, but otherwise it might lead to unexpected results.

I tried also a different implementation based on `find` instead of `gmatch` that I expected to be faster, because it only allocated half as many strings, but it turned out to be the same speed.

Ref. https://github.com/tomasklaen/uosc/pull/625#issuecomment-1732069651