### PR TITLE
fix: render spaces at the end of the search query

### DIFF
--- a/scripts/uosc/elements/Menu.lua
+++ b/scripts/uosc/elements/Menu.lua
@@ -1089,7 +1089,9 @@ function Menu:render()
 			-- Title
 			if menu.search then
 				if menu.search.query ~= '' then
-					ass:txt(bx - spacing, title_ay + (title_height / 2), 6, ass_escape(menu.search.query), {
+					-- Add a ZWNBSP suffix to prevent libass from trimming any trailing spaces
+					local query = ass_escape(menu.search.query) .. '\239\187\191'
+					ass:txt(bx - spacing, title_ay + (title_height / 2), 6, query, {
 						size = self.font_size, color = bgt, wrap = 2, opacity = menu_opacity,
 						clip = '\\clip(' .. ax + spacing .. ',' .. title_ay .. ',' .. bx - spacing .. ',' .. ay .. ')',
 					})


### PR DESCRIPTION
Currently the text does not advance to the left when spaces are entered, which must mean that libass trims any trailing spaces. Appending a ZWNBSP at the end prevents any trimming.