### PR TITLE
fix: deletion of unicode characters

### DIFF
--- a/scripts/uosc/elements/Menu.lua
+++ b/scripts/uosc/elements/Menu.lua
@@ -757,11 +757,12 @@ end
 
 ---@param event? string
 function Menu:search_backspace(event)
-	local pos, old_query, is_palette = #self.current.search.query - 1, self.current.search.query, self.current.palette
+	local pos, old_query, is_palette = #self.current.search.query, self.current.search.query, self.current.palette
 	-- The while loop is for skipping utf8 continuation bytes
 	while pos > 1 and old_query:byte(pos) >= 0x80 and old_query:byte(pos) <= 0xbf do
 		pos = pos - 1
 	end
+	pos = pos - 1
 	local new_query = old_query:sub(1, pos)
 	if new_query ~= old_query and (is_palette or not self.type_to_search or pos > 0) then
 		self:search_query_update(new_query)


### PR DESCRIPTION
I changed that logic a bit at some point during development and apparently never tested with non ascii characters since then :disappointed: 

It used to go to the first byte of the multi byte utf8 character and cut off everything after that, instead of going to one byte before that.