### PR TITLE
feat!: reworked config options for fullscreen scale adjustments

### DIFF
--- a/script-opts/uosc.conf
+++ b/script-opts/uosc.conf
@@ -4,7 +4,6 @@ timeline_style=line
 timeline_line_width=2
 # Timeline size when fully expanded, in pixels, 0 to disable
 timeline_size=40
-timeline_size_fullscreen=60
 # Comma separated states when timeline should always be fully visible. available: paused, audio, image, video, idle
 timeline_persistency=paused
 # Timeline opacity
@@ -85,7 +84,6 @@ progress_line_width=20
 #   toggle:{icon}:{prop} = cycle:{icon}:{prop}:no/yes!
 controls=menu,gap,subtitles,<has_many_audio>audio,<has_many_video>video,<has_many_edition>editions,<stream>stream-quality,gap,space,speed,space,shuffle,loop-playlist,loop-file,gap,prev,items,next,gap,fullscreen
 controls_size=32
-controls_size_fullscreen=40
 controls_margin=8
 controls_spacing=2
 controls_persistency=
@@ -93,7 +91,6 @@ controls_persistency=
 # Where to display volume controls: none, left, right
 volume=right
 volume_size=40
-volume_size_fullscreen=52
 volume_opacity=0.9
 volume_border=1
 volume_step=1
@@ -107,9 +104,7 @@ speed_persistency=
 
 # Controls all menus, such as context menu, subtitle loader/selector, etc
 menu_item_height=36
-menu_item_height_fullscreen=50
 menu_min_width=260
-menu_min_width_fullscreen=360
 menu_opacity=1
 menu_parent_opacity=0.4
 # Determines if `/` or `ctrl+f` is required to activate the search, or if typing
@@ -121,7 +116,6 @@ menu_type_to_search=yes
 # Can be: never, no-border, always
 top_bar=no-border
 top_bar_size=40
-top_bar_size_fullscreen=46
 top_bar_controls=yes
 # Can be: `no` (hide), `yes` (inherit title from mpv.conf), or a custom template string
 top_bar_title=yes
@@ -154,7 +148,9 @@ autoload_types=video,audio,image
 shuffle=no
 
 # Scale the interface by this factor
-ui_scale=1
+scale=1
+# Scale in fullscreen
+scale_fullscreen=1.5
 # Adjust the text scaling to fit your font
 font_scale=1
 # Border of text and icons when drawn directly on top of video

--- a/script-opts/uosc.conf
+++ b/script-opts/uosc.conf
@@ -150,7 +150,7 @@ shuffle=no
 # Scale the interface by this factor
 scale=1
 # Scale in fullscreen
-scale_fullscreen=1.5
+scale_fullscreen=1.3
 # Adjust the text scaling to fit your font
 font_scale=1
 # Border of text and icons when drawn directly on top of video

--- a/scripts/uosc/elements/Button.lua
+++ b/scripts/uosc/elements/Button.lua
@@ -47,7 +47,7 @@ function Button:render()
 	-- Background
 	if is_hover_or_active then
 		ass:rect(self.ax, self.ay, self.bx, self.by, {
-			color = self.active and background or foreground, radius = 2,
+			color = self.active and background or foreground, radius = state.radius,
 			opacity = visibility * (self.active and 1 or 0.3),
 		})
 	end
@@ -64,7 +64,7 @@ function Button:render()
 		local width, height = math.ceil(badge_width + (badge_font_size / 7) * 2), math.ceil(badge_font_size * 0.93)
 		local bx, by = self.bx - 1, self.by - 1
 		ass:rect(bx - width, by - height, bx, by, {
-			color = foreground, radius = 2, opacity = visibility,
+			color = foreground, radius = state.radius, opacity = visibility,
 			border = self.active and 0 or 1, border_color = background,
 		})
 		ass:txt(bx - width / 2, by - height / 2, 5, self.badge, badge_opts)

--- a/scripts/uosc/elements/Button.lua
+++ b/scripts/uosc/elements/Button.lua
@@ -80,7 +80,7 @@ function Button:render()
 	-- Icon
 	local x, y = round(self.ax + (self.bx - self.ax) / 2), round(self.ay + (self.by - self.ay) / 2)
 	ass:icon(x, y, self.font_size, self.icon, {
-		color = foreground, border = self.active and 0 or options.text_border, border_color = background,
+		color = foreground, border = self.active and 0 or options.text_border * state.scale, border_color = background,
 		opacity = visibility, clip = icon_clip,
 	})
 

--- a/scripts/uosc/elements/Controls.lua
+++ b/scripts/uosc/elements/Controls.lua
@@ -225,9 +225,7 @@ end
 
 function Controls:update_dimensions()
 	local window_border = Elements.window_border.size
-	local size = state.fullormaxed and options.controls_size_fullscreen or options.controls_size
-	local spacing = options.controls_spacing
-	local margin = options.controls_margin
+	local size, spacing, margin = options.controls_size, options.controls_spacing, options.controls_margin
 
 	-- Disable when not enough space
 	local available_space = display.height - Elements.window_border.size * 2

--- a/scripts/uosc/elements/Controls.lua
+++ b/scripts/uosc/elements/Controls.lua
@@ -225,7 +225,9 @@ end
 
 function Controls:update_dimensions()
 	local window_border = Elements.window_border.size
-	local size, spacing, margin = options.controls_size, options.controls_spacing, options.controls_margin
+	local size = round(options.controls_size * state.scale)
+	local spacing = round(options.controls_spacing * state.scale)
+	local margin = round(options.controls_margin * state.scale)
 
 	-- Disable when not enough space
 	local available_space = display.height - Elements.window_border.size * 2

--- a/scripts/uosc/elements/Menu.lua
+++ b/scripts/uosc/elements/Menu.lua
@@ -258,7 +258,7 @@ function Menu:update_items(items)
 end
 
 function Menu:update_content_dimensions()
-	self.item_height = state.fullormaxed and options.menu_item_height_fullscreen or options.menu_item_height
+	self.item_height = options.menu_item_height
 	self.font_size = round(self.item_height * 0.48 * options.font_scale)
 	self.font_size_hint = self.font_size - 1
 	self.item_padding = round((self.item_height - self.font_size) * 0.6)
@@ -296,10 +296,7 @@ function Menu:update_dimensions()
 	-- and dumb titles with no search inputs. It could use a refactor.
 	local margin = round(self.item_height / 2)
 	local width_available, height_available = display.width - margin * 2, display.height - margin * 2
-	local min_width = math.min(
-		state.fullormaxed and options.menu_min_width_fullscreen or options.menu_min_width,
-		width_available
-	)
+	local min_width = math.min(options.menu_min_width, width_available)
 
 	for _, menu in ipairs(self.all) do
 		local width = math.max(menu.search and menu.search.max_width or 0, menu.max_width)

--- a/scripts/uosc/elements/Menu.lua
+++ b/scripts/uosc/elements/Menu.lua
@@ -1099,7 +1099,7 @@ function Menu:render()
 			local highlight_opacity = 0 + (item.active and 0.8 or 0) + (menu.selected_index == index and 0.15 or 0)
 			if not is_submenu and highlight_opacity > 0 then
 				ass:rect(ax + self.padding, item_ay, bx - self.padding, item_by, {
-					radius = 2, color = fg, opacity = highlight_opacity * text_opacity,
+					radius = state.radius, color = fg, opacity = highlight_opacity * text_opacity,
 					clip = item_clip,
 				})
 			end

--- a/scripts/uosc/elements/Speed.lua
+++ b/scripts/uosc/elements/Speed.lua
@@ -186,7 +186,8 @@ function Speed:render()
 	-- Speed value
 	local speed_text = (round(state.speed * 100) / 100) .. 'x'
 	ass:txt(half_x, ay + (notch_ay_big - ay) / 2, 5, speed_text, {
-		size = self.font_size, color = bgt, border = options.text_border, border_color = bg, opacity = opacity,
+		size = self.font_size, color = bgt, border = options.text_border * state.scale, border_color = bg,
+		opacity = opacity,
 	})
 
 	return ass

--- a/scripts/uosc/elements/Speed.lua
+++ b/scripts/uosc/elements/Speed.lua
@@ -126,7 +126,9 @@ function Speed:render()
 	local ass = assdraw.ass_new()
 
 	-- Background
-	ass:rect(self.ax, self.ay, self.bx, self.by, {color = bg, radius = 2, opacity = opacity * options.speed_opacity})
+	ass:rect(self.ax, self.ay, self.bx, self.by, {
+		color = bg, radius = state.radius, opacity = opacity * options.speed_opacity
+	})
 
 	-- Coordinates
 	local ax, ay = self.ax, self.ay

--- a/scripts/uosc/elements/Timeline.lua
+++ b/scripts/uosc/elements/Timeline.lua
@@ -12,7 +12,7 @@ function Timeline:init()
 	self.size = 0
 	self.progress_size = 0
 	self.font_size = 0
-	self.top_border = options.timeline_border
+	self.top_border = 0
 	self.is_hovered = false
 	self.has_thumbnail = false
 
@@ -41,7 +41,8 @@ end
 function Timeline:get_is_hovered() return self.enabled and self.is_hovered end
 
 function Timeline:update_dimensions()
-	self.size = options.timeline_size
+	self.size = round(options.timeline_size * state.scale)
+	self.top_border = round(options.timeline_border * state.scale)
 	self.font_size = math.floor(math.min((self.size + 60) * 0.2, self.size * 0.96) * options.font_scale)
 	self.ax = Elements.window_border.size
 	self.ay = display.height - Elements.window_border.size - self.size - self.top_border
@@ -111,10 +112,7 @@ function Timeline:on_prop_fullormaxed()
 	self:update_dimensions()
 end
 function Timeline:on_display() self:update_dimensions() end
-function Timeline:on_options()
-	self.top_border = options.timeline_border
-	self:update_dimensions()
-end
+function Timeline:on_options() self:update_dimensions() end
 function Timeline:handle_cursor_up()
 	if self.pressed then
 		mp.set_property_native('pause', self.pressed.pause)
@@ -395,19 +393,21 @@ function Timeline:render()
 			and thumbnail.width ~= 0
 			and thumbnail.height ~= 0
 		then
-			local scale_x, scale_y = display.scale_x, display.scale_y
-			local border = math.ceil(2 * scale_x)
-			local margin_x, margin_y = round(tooltip_margin * scale_x), round(tooltip_gap * scale_y)
+			local border = math.ceil(2 * state.scale)
+			local margin_x, margin_y = round(tooltip_margin * state.scale), round(tooltip_gap * state.scale)
 			local thumb_x_margin, thumb_y_margin = border + margin_x + bax, border + margin_y
 			local thumb_width, thumb_height = thumbnail.width, thumbnail.height
 			local thumb_x = round(clamp(
-				thumb_x_margin, cursor_x * scale_x - thumb_width / 2,
-				display.width * scale_x - thumb_width - thumb_x_margin
+				thumb_x_margin, cursor_x * state.scale - thumb_width / 2,
+				display.width * state.scale - thumb_width - thumb_x_margin
 			))
-			local thumb_y = round(tooltip_anchor.ay * scale_y - thumb_y_margin - thumb_height)
-			local ax, ay = (thumb_x - border) / scale_x, (thumb_y - border) / scale_y
-			local bx, by = (thumb_x + thumb_width + border) / scale_x, (thumb_y + thumb_height + border) / scale_y
-			ass:rect(ax, ay, bx, by, {color = bg, border = 1, border_color = fg, border_opacity = 0.08, radius = 2})
+			local thumb_y = round(tooltip_anchor.ay * state.scale - thumb_y_margin - thumb_height)
+			local ax, ay = (thumb_x - border) / state.scale, (thumb_y - border) / state.scale
+			local bx = (thumb_x + thumb_width + border) / state.scale
+			local by = (thumb_y + thumb_height + border) / state.scale
+			ass:rect(ax, ay, bx, by, {
+				color = bg, border = 1, border_color = fg, border_opacity = 0.08, radius = state.radius
+			})
 			mp.commandv('script-message-to', 'thumbfast', 'thumb', hovered_seconds, thumb_x, thumb_y)
 			self.has_thumbnail, rendered_thumbnail = true, true
 			tooltip_anchor.ay = ay

--- a/scripts/uosc/elements/Timeline.lua
+++ b/scripts/uosc/elements/Timeline.lua
@@ -169,8 +169,8 @@ function Timeline:render()
 	local hide_text_ramp = hide_text_below / 2
 	local text_opacity = clamp(0, size - hide_text_below, hide_text_ramp) / hide_text_ramp
 
-	local tooltip_gap = 2
-	local tooltip_margin = 10
+	local tooltip_gap = round(2 * state.scale)
+	local tooltip_margin = round(10 * state.scale)
 	local timestamp_gap = tooltip_gap
 
 	local spacing = math.max(math.floor((self.size - self.font_size) / 2.5), 4)
@@ -350,7 +350,9 @@ function Timeline:render()
 		if buffered_playtime and options.buffered_time_threshold > 0
 			and buffered_playtime < options.buffered_time_threshold then
 			local x, align = fbx + 5, 4
-			local cache_opts = {size = self.font_size * 0.8, opacity = text_opacity * 0.6, border = 1}
+			local cache_opts = {
+				size = self.font_size * 0.8, opacity = text_opacity * 0.6, border = options.text_border * state.scale
+			}
 			local human = round(math.max(buffered_playtime, 0)) .. 's'
 			local width = text_width(human, cache_opts)
 			local time_width = timestamp_width(state.time_human, time_opts)

--- a/scripts/uosc/elements/Timeline.lua
+++ b/scripts/uosc/elements/Timeline.lua
@@ -38,14 +38,10 @@ function Timeline:get_effective_size()
 	return self.progress_size + math.ceil((self.size - self.progress_size) * self:get_visibility())
 end
 
-function Timeline:get_effective_line_width()
-	return state.fullormaxed and options.timeline_line_width_fullscreen or options.timeline_line_width
-end
-
 function Timeline:get_is_hovered() return self.enabled and self.is_hovered end
 
 function Timeline:update_dimensions()
-	self.size = state.fullormaxed and options.timeline_size_fullscreen or options.timeline_size
+	self.size = options.timeline_size
 	self.font_size = math.floor(math.min((self.size + 60) * 0.2, self.size * 0.96) * options.font_scale)
 	self.ax = Elements.window_border.size
 	self.ay = display.height - Elements.window_border.size - self.size - self.top_border
@@ -188,9 +184,8 @@ function Timeline:render()
 
 	if is_line then
 		local minimized_fraction = 1 - math.min((size - self.progress_size) / ((self.size - self.progress_size) / 8), 1)
-		local line_width_normal = self:get_effective_line_width()
-		local progress_delta = self.progress_size > 0 and options.progress_line_width - line_width_normal or 0
-		line_width = line_width_normal - (progress_delta * minimized_fraction)
+		local progress_delta = self.progress_size > 0 and options.progress_line_width - options.timeline_line_width or 0
+		line_width = options.timeline_line_width - (progress_delta * minimized_fraction)
 		fax = bax + (self.width - line_width) * progress
 		fbx = fax + line_width
 		line_width = line_width - 1

--- a/scripts/uosc/elements/Timeline.lua
+++ b/scripts/uosc/elements/Timeline.lua
@@ -398,17 +398,17 @@ function Timeline:render()
 			and thumbnail.height ~= 0
 		then
 			local border = math.ceil(math.max(2, state.radius / 2) * state.scale)
-			local margin_x, margin_y = round(tooltip_margin * state.scale), round(tooltip_gap * state.scale)
+			local margin_x, margin_y = tooltip_margin, tooltip_gap
 			local thumb_x_margin, thumb_y_margin = border + margin_x + bax, border + margin_y
 			local thumb_width, thumb_height = thumbnail.width, thumbnail.height
 			local thumb_x = round(clamp(
-				thumb_x_margin, cursor_x * state.scale - thumb_width / 2,
-				display.width * state.scale - thumb_width - thumb_x_margin
+				thumb_x_margin,
+				cursor_x - thumb_width / 2,
+				display.width - thumb_width - thumb_x_margin
 			))
-			local thumb_y = round(tooltip_anchor.ay * state.scale - thumb_y_margin - thumb_height)
-			local ax, ay = (thumb_x - border) / state.scale, (thumb_y - border) / state.scale
-			local bx = (thumb_x + thumb_width + border) / state.scale
-			local by = (thumb_y + thumb_height + border) / state.scale
+			local thumb_y = round(tooltip_anchor.ay - thumb_y_margin - thumb_height)
+			local ax, ay = (thumb_x - border), (thumb_y - border)
+			local bx, by = (thumb_x + thumb_width + border), (thumb_y + thumb_height + border)
 			ass:rect(ax, ay, bx, by, {
 				color = bg, border = 1, border_color = fg, border_opacity = 0.08, radius = state.radius
 			})

--- a/scripts/uosc/elements/Timeline.lua
+++ b/scripts/uosc/elements/Timeline.lua
@@ -13,6 +13,8 @@ function Timeline:init()
 	self.progress_size = 0
 	self.font_size = 0
 	self.top_border = 0
+	self.line_width = 0
+	self.progress_line_width = 0
 	self.is_hovered = false
 	self.has_thumbnail = false
 
@@ -43,6 +45,8 @@ function Timeline:get_is_hovered() return self.enabled and self.is_hovered end
 function Timeline:update_dimensions()
 	self.size = round(options.timeline_size * state.scale)
 	self.top_border = round(options.timeline_border * state.scale)
+	self.line_width = round(options.timeline_line_width * state.scale)
+	self.progress_line_width = round(options.progress_line_width * state.scale)
 	self.font_size = math.floor(math.min((self.size + 60) * 0.2, self.size * 0.96) * options.font_scale)
 	self.ax = Elements.window_border.size
 	self.ay = display.height - Elements.window_border.size - self.size - self.top_border
@@ -73,7 +77,7 @@ function Timeline:toggle_progress()
 end
 
 function Timeline:get_time_at_x(x)
-	local line_width = (options.timeline_style == 'line' and options.timeline_line_width - 1 or 0)
+	local line_width = (options.timeline_style == 'line' and self.line_width - 1 or 0)
 	local time_width = self.width - line_width - 1
 	local fax = (time_width) * state.time / state.duration
 	local fbx = fax + line_width
@@ -182,8 +186,8 @@ function Timeline:render()
 
 	if is_line then
 		local minimized_fraction = 1 - math.min((size - self.progress_size) / ((self.size - self.progress_size) / 8), 1)
-		local progress_delta = self.progress_size > 0 and options.progress_line_width - options.timeline_line_width or 0
-		line_width = options.timeline_line_width - (progress_delta * minimized_fraction)
+		local progress_delta = self.progress_size > 0 and self.progress_line_width - self.line_width or 0
+		line_width = self.line_width - (progress_delta * minimized_fraction)
 		fax = bax + (self.width - line_width) * progress
 		fbx = fax + line_width
 		line_width = line_width - 1

--- a/scripts/uosc/elements/Timeline.lua
+++ b/scripts/uosc/elements/Timeline.lua
@@ -397,7 +397,7 @@ function Timeline:render()
 			and thumbnail.width ~= 0
 			and thumbnail.height ~= 0
 		then
-			local border = math.ceil(2 * state.scale)
+			local border = math.ceil(math.max(2, state.radius / 2) * state.scale)
 			local margin_x, margin_y = round(tooltip_margin * state.scale), round(tooltip_gap * state.scale)
 			local thumb_x_margin, thumb_y_margin = border + margin_x + bax, border + margin_y
 			local thumb_width, thumb_height = thumbnail.width, thumbnail.height

--- a/scripts/uosc/elements/TopBar.lua
+++ b/scripts/uosc/elements/TopBar.lua
@@ -112,7 +112,7 @@ function TopBar:decide_titles()
 end
 
 function TopBar:update_dimensions()
-	self.size = state.fullormaxed and options.top_bar_size_fullscreen or options.top_bar_size
+	self.size = options.top_bar_size
 	self.icon_size = round(self.size * 0.5)
 	self.spacing = math.ceil(self.size * 0.25)
 	self.font_size = math.floor((self.size - (self.spacing * 2)) * options.font_scale)

--- a/scripts/uosc/elements/TopBar.lua
+++ b/scripts/uosc/elements/TopBar.lua
@@ -34,7 +34,7 @@ function TopBarButton:render()
 	local width, height = self.bx - self.ax, self.by - self.ay
 	local icon_size = math.min(width, height) * 0.5
 	ass:icon(self.ax + width / 2, self.ay + height / 2, icon_size, self.icon, {
-		opacity = visibility, border = options.text_border,
+		opacity = visibility, border = options.text_border * state.scale,
 	})
 
 	return ass
@@ -212,7 +212,8 @@ function TopBar:render()
 			local main_title = self.show_alt_title and self.alt_title or self.main_title
 			if main_title then
 				local opts = {
-					size = self.font_size, wrap = 2, color = bgt, border = 1, border_color = bg, opacity = visibility,
+					size = self.font_size, wrap = 2, color = bgt, opacity = visibility,
+					border = options.text_border * state.scale, border_color = bg,
 					clip = string.format('\\clip(%d, %d, %d, %d)', self.ax, self.ay, max_bx, self.by),
 				}
 				local bx = round(math.min(max_bx, title_ax + text_width(main_title, opts) + padding * 2))
@@ -238,7 +239,8 @@ function TopBar:render()
 				local height = font_size * 1.3
 				local by = title_ay + height
 				local opts = {
-					size = font_size, wrap = 2, color = bgt, border = 1, border_color = bg, opacity = visibility
+					size = font_size, wrap = 2, color = bgt,
+					border = options.text_border * state.scale, border_color = bg, opacity = visibility
 				}
 				local bx = round(math.min(max_bx, title_ax + text_width(self.alt_title, opts) + padding * 2))
 				opts.clip = string.format('\\clip(%d, %d, %d, %d)', title_ax, title_ay, bx, by)
@@ -256,7 +258,7 @@ function TopBar:render()
 				local text = '└ ' .. state.current_chapter.index .. ': ' .. state.current_chapter.title
 				local opts = {
 					size = font_size, italic = true, wrap = 2, color = bgt,
-					border = 1, border_color = bg, opacity = visibility * 0.8,
+					border = options.text_border * state.scale, border_color = bg, opacity = visibility * 0.8,
 				}
 				local rect = {
 					ax = title_ax,

--- a/scripts/uosc/elements/TopBar.lua
+++ b/scripts/uosc/elements/TopBar.lua
@@ -112,7 +112,7 @@ function TopBar:decide_titles()
 end
 
 function TopBar:update_dimensions()
-	self.size = options.top_bar_size
+	self.size = round(options.top_bar_size * state.scale)
 	self.icon_size = round(self.size * 0.5)
 	self.spacing = math.ceil(self.size * 0.25)
 	self.font_size = math.floor((self.size - (self.spacing * 2)) * options.font_scale)
@@ -196,7 +196,7 @@ function TopBar:render()
 				bx = round(title_ax + text_width(text, opts) + padding * 2),
 				by = self.by - bg_margin
 			}
-			ass:rect(rect.ax, rect.ay, rect.bx, rect.by, {color = fg, opacity = visibility, radius = 2})
+			ass:rect(rect.ax, rect.ay, rect.bx, rect.by, {color = fg, opacity = visibility, radius = state.radius})
 			ass:txt(rect.ax + (rect.bx - rect.ax) / 2, rect.ay + (rect.by - rect.ay) / 2, 5, formatted_text, opts)
 			title_ax = rect.bx + bg_margin
 
@@ -215,7 +215,7 @@ function TopBar:render()
 					size = self.font_size, wrap = 2, color = bgt, border = 1, border_color = bg, opacity = visibility,
 					clip = string.format('\\clip(%d, %d, %d, %d)', self.ax, self.ay, max_bx, self.by),
 				}
-				local bx = math.min(max_bx, title_ax + text_width(main_title, opts) + padding * 2)
+				local bx = round(math.min(max_bx, title_ax + text_width(main_title, opts) + padding * 2))
 				local by = self.by - bg_margin
 				local title_rect = {ax = title_ax, ay = title_ay, bx = bx, by = by}
 
@@ -226,7 +226,7 @@ function TopBar:render()
 				end
 
 				ass:rect(title_rect.ax, title_rect.ay, title_rect.bx, title_rect.by, {
-					color = bg, opacity = visibility * options.top_bar_title_opacity, radius = 2,
+					color = bg, opacity = visibility * options.top_bar_title_opacity, radius = state.radius,
 				})
 				ass:txt(title_ax + padding, self.ay + (self.size / 2), 4, main_title, opts)
 				title_ay = by + 1
@@ -240,10 +240,10 @@ function TopBar:render()
 				local opts = {
 					size = font_size, wrap = 2, color = bgt, border = 1, border_color = bg, opacity = visibility
 				}
-				local bx = math.min(max_bx, title_ax + text_width(self.alt_title, opts) + padding * 2)
+				local bx = round(math.min(max_bx, title_ax + text_width(self.alt_title, opts) + padding * 2))
 				opts.clip = string.format('\\clip(%d, %d, %d, %d)', title_ax, title_ay, bx, by)
 				ass:rect(title_ax, title_ay, bx, by, {
-					color = bg, opacity = visibility * options.top_bar_title_opacity, radius = 2,
+					color = bg, opacity = visibility * options.top_bar_title_opacity, radius = state.radius,
 				})
 				ass:txt(title_ax + padding, title_ay + height / 2, 4, self.alt_title, opts)
 				title_ay = by + 1
@@ -261,12 +261,12 @@ function TopBar:render()
 				local rect = {
 					ax = title_ax,
 					ay = title_ay,
-					bx = math.min(max_bx, title_ax + text_width(text, opts) + padding * 2),
+					bx = round(math.min(max_bx, title_ax + text_width(text, opts) + padding * 2)),
 					by = title_ay + height
 				}
 				opts.clip = string.format('\\clip(%d, %d, %d, %d)', title_ax, title_ay, rect.bx, rect.by)
 				ass:rect(rect.ax, rect.ay, rect.bx, rect.by, {
-					color = bg, opacity = visibility * options.top_bar_title_opacity, radius = 2,
+					color = bg, opacity = visibility * options.top_bar_title_opacity, radius = state.radius,
 				})
 				ass:txt(rect.ax + padding, rect.ay + height / 2, 4, text, opts)
 				title_ay = rect.by + 1

--- a/scripts/uosc/elements/Volume.lua
+++ b/scripts/uosc/elements/Volume.lua
@@ -35,6 +35,12 @@ function VolumeSlider:init(props)
 	self.nudge_size = 0
 	self.draw_nudge = false
 	self.spacing = 0
+	self.border_size = 0
+	self:update_dimensions()
+end
+
+function VolumeSlider:update_dimensions()
+	self.border_size = math.max(1, round(options.volume_border * state.scale))
 end
 
 function VolumeSlider:get_visibility() return Elements.volume:get_visibility(self) end
@@ -46,10 +52,12 @@ function VolumeSlider:set_volume(volume)
 end
 
 function VolumeSlider:set_from_cursor()
-	local volume_fraction = (self.by - cursor.y - options.volume_border) / (self.by - self.ay - options.volume_border)
+	local volume_fraction = (self.by - cursor.y - self.border_size) / (self.by - self.ay - self.border_size)
 	self:set_volume(volume_fraction * state.volume_max)
 end
 
+function VolumeSlider:on_display() self:update_dimensions() end
+function VolumeSlider:on_options() self:update_dimensions() end
 function VolumeSlider:on_coordinates()
 	if type(state.volume_max) ~= 'number' or state.volume_max <= 0 then return end
 	local width = self.bx - self.ax
@@ -86,8 +94,8 @@ function VolumeSlider:render()
 
 	local ass = assdraw.ass_new()
 	local nudge_y, nudge_size = self.draw_nudge and self.nudge_y or -INFINITY, self.nudge_size
-	local volume_y = self.ay + options.volume_border +
-		((height - (options.volume_border * 2)) * (1 - math.min(state.volume / state.volume_max, 1)))
+	local volume_y = self.ay + self.border_size +
+		((height - (self.border_size * 2)) * (1 - math.min(state.volume / state.volume_max, 1)))
 
 	-- Draws a rectangle with nudge at requested position
 	---@param p number Padding from slider edges.
@@ -154,7 +162,7 @@ function VolumeSlider:render()
 
 	-- BG & FG paths
 	local bg_path = create_nudged_path(0)
-	local fg_path = create_nudged_path(options.volume_border, volume_y)
+	local fg_path = create_nudged_path(self.border_size, volume_y)
 
 	-- Background
 	ass:new_event()
@@ -193,7 +201,7 @@ function VolumeSlider:render()
 
 	-- Disabled stripes for no audio
 	if not state.has_audio then
-		local fg_100_path = create_nudged_path(options.volume_border)
+		local fg_100_path = create_nudged_path(self.border_size)
 		local texture_opts = {
 			size = 200, color = 'ffffff', opacity = visibility * 0.1, anchor_x = ax,
 			clip = '\\clip(' .. fg_100_path.scale .. ',' .. fg_100_path.text .. ')',

--- a/scripts/uosc/elements/Volume.lua
+++ b/scripts/uosc/elements/Volume.lua
@@ -226,7 +226,7 @@ function Volume:get_visibility()
 end
 
 function Volume:update_dimensions()
-	local width = state.fullormaxed and options.volume_size_fullscreen or options.volume_size
+	local width = options.volume_size
 	local controls, timeline, top_bar = Elements.controls, Elements.timeline, Elements.top_bar
 	local min_y = top_bar.enabled and top_bar.by or 0
 	local max_y = (controls and controls.enabled and controls.ay) or (timeline.enabled and timeline.ay)

--- a/scripts/uosc/elements/Volume.lua
+++ b/scripts/uosc/elements/Volume.lua
@@ -99,7 +99,7 @@ function VolumeSlider:render()
 
 	-- Draws a rectangle with nudge at requested position
 	---@param p number Padding from slider edges.
-	---@param r number Padding from slider edges.
+	---@param r number Border radius.
 	---@param cy? number A y coordinate where to clip the path from the bottom.
 	function create_nudged_path(p, r, cy)
 		cy = cy or ay + p

--- a/scripts/uosc/elements/Volume.lua
+++ b/scripts/uosc/elements/Volume.lua
@@ -35,7 +35,6 @@ function VolumeSlider:init(props)
 	self.nudge_size = 0
 	self.draw_nudge = false
 	self.spacing = 0
-	self.radius = 1
 end
 
 function VolumeSlider:get_visibility() return Elements.volume:get_visibility(self) end
@@ -58,7 +57,6 @@ function VolumeSlider:on_coordinates()
 	self.nudge_size = round(width * 0.18)
 	self.draw_nudge = self.ay < self.nudge_y
 	self.spacing = round(width * 0.2)
-	self.radius = math.max(2, (self.bx - self.ax) / 10)
 end
 function VolumeSlider:on_global_mouse_move()
 	if self.pressed then self:set_from_cursor() end
@@ -97,7 +95,7 @@ function VolumeSlider:render()
 	function create_nudged_path(p, cy)
 		cy = cy or ay + p
 		local ax, bx, by = ax + p, bx - p, by - p
-		local r = math.max(1, self.radius - p)
+		local r = math.max(1, state.radius)
 		local d, rh = r * 2, r / 2
 		local nudge_size = ((QUARTER_PI_SIN * (nudge_size - p)) + p) / QUARTER_PI_SIN
 		local path = assdraw.ass_new()
@@ -226,7 +224,7 @@ function Volume:get_visibility()
 end
 
 function Volume:update_dimensions()
-	local width = options.volume_size
+	local width = round(options.volume_size * state.scale)
 	local controls, timeline, top_bar = Elements.controls, Elements.timeline, Elements.top_bar
 	local min_y = top_bar.enabled and top_bar.by or 0
 	local max_y = (controls and controls.enabled and controls.ay) or (timeline.enabled and timeline.ay)

--- a/scripts/uosc/elements/Volume.lua
+++ b/scripts/uosc/elements/Volume.lua
@@ -99,11 +99,11 @@ function VolumeSlider:render()
 
 	-- Draws a rectangle with nudge at requested position
 	---@param p number Padding from slider edges.
+	---@param r number Padding from slider edges.
 	---@param cy? number A y coordinate where to clip the path from the bottom.
-	function create_nudged_path(p, cy)
+	function create_nudged_path(p, r, cy)
 		cy = cy or ay + p
 		local ax, bx, by = ax + p, bx - p, by - p
-		local r = math.max(1, state.radius)
 		local d, rh = r * 2, r / 2
 		local nudge_size = ((QUARTER_PI_SIN * (nudge_size - p)) + p) / QUARTER_PI_SIN
 		local path = assdraw.ass_new()
@@ -161,8 +161,8 @@ function VolumeSlider:render()
 	end
 
 	-- BG & FG paths
-	local bg_path = create_nudged_path(0)
-	local fg_path = create_nudged_path(self.border_size, volume_y)
+	local bg_path = create_nudged_path(0, state.radius + self.border_size)
+	local fg_path = create_nudged_path(self.border_size, state.radius, volume_y)
 
 	-- Background
 	ass:new_event()

--- a/scripts/uosc/elements/Volume.lua
+++ b/scripts/uosc/elements/Volume.lua
@@ -17,7 +17,7 @@ function MuteButton:render()
 	local icon_name = state.mute and 'volume_off' or 'volume_up'
 	local width = self.bx - self.ax
 	ass:icon(self.ax + (width / 2), self.by, width * 0.7, icon_name,
-		{border = options.text_border, opacity = options.volume_opacity * visibility, align = 2}
+		{border = options.text_border * state.scale, opacity = options.volume_opacity * visibility, align = 2}
 	)
 	return ass
 end

--- a/scripts/uosc/elements/WindowBorder.lua
+++ b/scripts/uosc/elements/WindowBorder.lua
@@ -13,7 +13,7 @@ end
 function WindowBorder:decide_enabled()
 	self.enabled = options.window_border_size > 0 and not state.fullormaxed and not state.border
 	    and state.title_bar == false
-	self.size = self.enabled and options.window_border_size or 0
+	self.size = self.enabled and round(options.window_border_size * state.scale) or 0
 end
 
 function WindowBorder:on_prop_border() self:decide_enabled() end

--- a/scripts/uosc/lib/ass.lua
+++ b/scripts/uosc/lib/ass.lua
@@ -79,10 +79,10 @@ end
 function ass_mt:tooltip(element, value, opts)
 	if value == '' then return end
 	opts = opts or {}
-	opts.size = opts.size or 16
-	opts.border = options.text_border
+	opts.size = opts.size or round(16 * state.scale)
+	opts.border = options.text_border * state.scale
 	opts.border_color = bg
-	opts.margin = opts.margin or 10
+	opts.margin = opts.margin or round(10 * state.scale)
 	opts.opacity = opts.opacity or options.timeline_opacity
 	opts.lines = opts.lines or 1
 	local padding_y = round(opts.size / 6)

--- a/scripts/uosc/lib/ass.lua
+++ b/scripts/uosc/lib/ass.lua
@@ -94,10 +94,10 @@ function ass_mt:tooltip(element, value, opts)
 	local width_half = (opts.width_overwrite or text_width(value, opts)) / 2 + padding_x
 	local min_edge_distance = width_half + opts.margin + Elements.window_border.size
 	x = clamp(min_edge_distance, x, display.width - min_edge_distance)
-	local ax, bx = x - width_half, x + width_half
+	local ax, bx = round(x - width_half), round(x + width_half)
 	local ay = (align_top and y - opts.size * opts.lines - 2 * padding_y or y)
 	local by = (align_top and y or y + opts.size * opts.lines + 2 * padding_y)
-	self:rect(ax, ay, bx, by, {color = bg, opacity = opts.opacity, radius = 2})
+	self:rect(ax, ay, bx, by, {color = bg, opacity = opts.opacity, radius = state.radius})
 	opts.opacity = nil
 	self:txt(x, align_top and y - padding_y or y + padding_y, align_top and 2 or 8, value, opts)
 	return { ax = element.ax, ay = ay, bx = element.bx, by = by }
@@ -129,7 +129,7 @@ function ass_mt:rect(ax, ay, bx, by, opts)
 	self:new_event()
 	self.text = self.text .. '{' .. tags .. '}'
 	self:draw_start()
-	if opts.radius then
+	if opts.radius and opts.radius > 0 then
 		self:round_rect_cw(ax, ay, bx, by, opts.radius)
 	else
 		self:rect_cw(ax, ay, bx, by)

--- a/scripts/uosc/main.lua
+++ b/scripts/uosc/main.lua
@@ -499,7 +499,7 @@ state = {
 	margin_right = 0,
 	hidpi_scale = 1,
 	scale = 1,
-	radius = 4
+	radius = 0
 }
 thumbnail = {width = 0, height = 0, disabled = false}
 external = {} -- Properties set by external scripts

--- a/scripts/uosc/main.lua
+++ b/scripts/uosc/main.lua
@@ -304,7 +304,7 @@ end
 
 --[[ STATE ]]
 
-display = {width = 1280, height = 720, scale_x = 1, scale_y = 1, initialized = false}
+display = {width = 1280, height = 720, initialized = false}
 cursor = {
 	x = 0,
 	y = 0,
@@ -373,7 +373,7 @@ cursor = {
 		end
 
 		-- Add 0.5 to be in the middle of the pixel
-		cursor.x, cursor.y = (x + 0.5) / display.scale_x, (y + 0.5) / display.scale_y
+		cursor.x, cursor.y = x + 0.5, y + 0.5
 
 		if old_x ~= cursor.x or old_y ~= cursor.y then
 			Elements:update_proximities()
@@ -498,6 +498,8 @@ state = {
 	margin_left = 0,
 	margin_right = 0,
 	hidpi_scale = 1,
+	scale = 1,
+	radius = 4
 }
 thumbnail = {width = 0, height = 0, disabled = false}
 external = {} -- Properties set by external scripts
@@ -514,12 +516,11 @@ require('lib/menus')
 --[[ STATE UPDATERS ]]
 
 function update_display_dimensions()
-	local scale = (state.hidpi_scale or 1) * (state.fullormaxed and options.scale_fullscreen or options.scale)
+	state.scale = (state.hidpi_scale or 1) * (state.fullormaxed and options.scale_fullscreen or options.scale)
+	state.radius = round(2 * state.scale)
 	local real_width, real_height = mp.get_osd_size()
 	if real_width <= 0 then return end
-	local scaled_width, scaled_height = round(real_width / scale), round(real_height / scale)
-	display.width, display.height = scaled_width, scaled_height
-	display.scale_x, display.scale_y = real_width / scaled_width, real_height / scaled_height
+	display.width, display.height = real_width, real_height
 	display.initialized = true
 
 	-- Tell elements about this

--- a/scripts/uosc/main.lua
+++ b/scripts/uosc/main.lua
@@ -69,7 +69,7 @@ defaults = {
 	shuffle = false,
 
 	scale = 1,
-	scale_fullscreen = 1.5,
+	scale_fullscreen = 1.3,
 	font_scale = 1,
 	text_border = 1.2,
 	text_width_estimation = true,

--- a/scripts/uosc/main.lua
+++ b/scripts/uosc/main.lua
@@ -16,9 +16,7 @@ require('lib/std')
 defaults = {
 	timeline_style = 'line',
 	timeline_line_width = 2,
-	timeline_line_width_fullscreen = 3,
 	timeline_size = 40,
-	timeline_size_fullscreen = 60,
 	progress = 'windowed',
 	progress_size = 2,
 	progress_line_width = 20,
@@ -31,14 +29,12 @@ defaults = {
 
 	controls = 'menu,gap,subtitles,<has_many_audio>audio,<has_many_video>video,<has_many_edition>editions,<stream>stream-quality,gap,space,speed,space,shuffle,loop-playlist,loop-file,gap,prev,items,next,gap,fullscreen',
 	controls_size = 32,
-	controls_size_fullscreen = 40,
 	controls_margin = 8,
 	controls_spacing = 2,
 	controls_persistency = '',
 
 	volume = 'right',
 	volume_size = 40,
-	volume_size_fullscreen = 52,
 	volume_persistency = '',
 	volume_opacity = 0.9,
 	volume_border = 1,
@@ -50,16 +46,13 @@ defaults = {
 	speed_step_is_factor = false,
 
 	menu_item_height = 36,
-	menu_item_height_fullscreen = 50,
 	menu_min_width = 260,
-	menu_min_width_fullscreen = 360,
 	menu_opacity = 1,
 	menu_parent_opacity = 0.4,
 	menu_type_to_search = true,
 
 	top_bar = 'no-border',
 	top_bar_size = 40,
-	top_bar_size_fullscreen = 46,
 	top_bar_persistency = '',
 	top_bar_controls = true,
 	top_bar_title = 'yes',
@@ -75,7 +68,8 @@ defaults = {
 	autoload_types = 'video,audio,image',
 	shuffle = false,
 
-	ui_scale = 1,
+	scale = 1,
+	scale_fullscreen = 1.5,
 	font_scale = 1,
 	text_border = 1.2,
 	text_width_estimation = true,
@@ -520,7 +514,7 @@ require('lib/menus')
 --[[ STATE UPDATERS ]]
 
 function update_display_dimensions()
-	local scale = (state.hidpi_scale or 1) * options.ui_scale
+	local scale = (state.hidpi_scale or 1) * (state.fullormaxed and options.scale_fullscreen or options.scale)
 	local real_width, real_height = mp.get_osd_size()
 	if real_width <= 0 then return end
 	local scaled_width, scaled_height = round(real_width / scale), round(real_height / scale)


### PR DESCRIPTION
Removed options:

```
timeline_size_fullscreen
controls_size_fullscreen
volume_size_fullscreen
menu_item_height_fullscreen
menu_min_width_fullscreen
top_bar_size_fullscreen
```

Additionally, `ui_scale` has been renamed to `scale`.

The scaling can now be controlled by these two new options:

```
scale=1
scale_fullscreen=1.3
```

closes #543