### PR TITLE
feat: clamp title and hint size to min 20% width

### DIFF
--- a/scripts/uosc/elements/Menu.lua
+++ b/scripts/uosc/elements/Menu.lua
@@ -1111,22 +1111,13 @@ function Menu:render()
 
 			local title_cut_x = content_bx
 			if item.hint_width > 0 then
-				local ratio = item.title_width / item.hint_width
-				if ratio <= 1 / 1.3 then
-					-- title is smaller
-					title_cut_x = math.ceil(content_ax + item.title_width)
-				elseif ratio >= 1.3 then
-					-- hint is smaller
-					title_cut_x = math.floor(content_bx - item.hint_width - spacing)
-				else
-					-- controls title & hint clipping proportional to the ratio of their widths
-					-- both title and hint get at least 20% of the width, unless they are smaller then that
-					local width = content_bx - content_ax
-					local title_min = math.min(item.title_width, width * 0.2)
-					local hint_min = math.min(item.hint_width, width * 0.2)
-					local title_ratio = item.title_width / (item.title_width + item.hint_width)
-					title_cut_x = round(content_ax + clamp(title_min, (width - spacing) * title_ratio, width - hint_min))
-				end
+				-- controls title & hint clipping proportional to the ratio of their widths
+				-- both title and hint get at least 50% of the width, unless they are smaller then that
+				local width = content_bx - content_ax - spacing
+				local title_min = math.min(item.title_width, width * 0.5)
+				local hint_min = math.min(item.hint_width, width * 0.5)
+				local title_ratio = item.title_width / (item.title_width + item.hint_width)
+				title_cut_x = round(content_ax + clamp(title_min, width * title_ratio, width - hint_min))
 			end
 
 			-- Hint

--- a/scripts/uosc/elements/Menu.lua
+++ b/scripts/uosc/elements/Menu.lua
@@ -1112,9 +1112,13 @@ function Menu:render()
 			local title_cut_x = content_bx
 			if item.hint_width > 0 then
 				-- controls title & hint clipping proportional to the ratio of their widths
+				-- both title and hint get at least 20% of the width, unless they are smaller then that
+				local width = content_bx - content_ax
+				local title_min = math.min(item.title_width, width * 0.2)
+				local hint_min = math.min(item.hint_width, width * 0.2)
 				local title_content_ratio = item.title_width / (item.title_width + item.hint_width)
-				title_cut_x = round(content_ax + (content_bx - content_ax - spacing) * title_content_ratio
-					+ (item.title_width > 0 and spacing / 2 or 0))
+				title_cut_x = round(content_ax + clamp(title_min, (width - spacing) * title_content_ratio
+					+ (item.title_width > 0 and spacing / 2 or 0), width - hint_min))
 			end
 
 			-- Hint

--- a/scripts/uosc/elements/Menu.lua
+++ b/scripts/uosc/elements/Menu.lua
@@ -1111,20 +1111,21 @@ function Menu:render()
 
 			local title_cut_x = content_bx
 			if item.hint_width > 0 then
-				local width = content_bx - content_ax
-				if math.abs(item.title_width - item.hint_width) < width * 0.3 then
+				local ratio = item.title_width / item.hint_width
+				if ratio <= 1 / 1.3 then
+					-- title is smaller
+					title_cut_x = math.ceil(content_ax + item.title_width)
+				elseif ratio >= 1.3 then
+					-- hint is smaller
+					title_cut_x = math.floor(content_bx - item.hint_width - spacing)
+				else
 					-- controls title & hint clipping proportional to the ratio of their widths
 					-- both title and hint get at least 20% of the width, unless they are smaller then that
+					local width = content_bx - content_ax
 					local title_min = math.min(item.title_width, width * 0.2)
 					local hint_min = math.min(item.hint_width, width * 0.2)
 					local title_ratio = item.title_width / (item.title_width + item.hint_width)
 					title_cut_x = round(content_ax + clamp(title_min, (width - spacing) * title_ratio, width - hint_min))
-				elseif item.title_width < item.hint_width then
-					-- title is smaller
-					title_cut_x = math.ceil(content_ax + item.title_width)
-				else
-					-- hint is smaller
-					title_cut_x = math.floor(content_bx - item.hint_width - spacing)
 				end
 			end
 

--- a/scripts/uosc/elements/Menu.lua
+++ b/scripts/uosc/elements/Menu.lua
@@ -1111,20 +1111,27 @@ function Menu:render()
 
 			local title_cut_x = content_bx
 			if item.hint_width > 0 then
-				-- controls title & hint clipping proportional to the ratio of their widths
-				-- both title and hint get at least 20% of the width, unless they are smaller then that
 				local width = content_bx - content_ax
-				local title_min = math.min(item.title_width, width * 0.2)
-				local hint_min = math.min(item.hint_width, width * 0.2)
-				local title_content_ratio = item.title_width / (item.title_width + item.hint_width)
-				title_cut_x = round(content_ax + clamp(title_min, (width - spacing) * title_content_ratio
-					+ (item.title_width > 0 and spacing / 2 or 0), width - hint_min))
+				if math.abs(item.title_width - item.hint_width) < width * 0.3 then
+					-- controls title & hint clipping proportional to the ratio of their widths
+					-- both title and hint get at least 20% of the width, unless they are smaller then that
+					local title_min = math.min(item.title_width, width * 0.2)
+					local hint_min = math.min(item.hint_width, width * 0.2)
+					local title_ratio = item.title_width / (item.title_width + item.hint_width)
+					title_cut_x = round(content_ax + clamp(title_min, (width - spacing) * title_ratio, width - hint_min))
+				elseif item.title_width < item.hint_width then
+					-- title is smaller
+					title_cut_x = math.ceil(content_ax + item.title_width)
+				else
+					-- hint is smaller
+					title_cut_x = math.floor(content_bx - item.hint_width - spacing)
+				end
 			end
 
 			-- Hint
 			if item.hint then
 				item.ass_safe_hint = item.ass_safe_hint or ass_escape(item.hint)
-				local clip = '\\clip(' .. title_cut_x .. ',' ..
+				local clip = '\\clip(' .. title_cut_x + spacing .. ',' ..
 					math.max(item_ay, ay) .. ',' .. bx .. ',' .. math.min(item_by, by) .. ')'
 				ass:txt(content_bx, item_center_y, 6, item.ass_safe_hint, {
 					size = self.font_size_hint, color = font_color, wrap = 2, opacity = 0.5 * menu_opacity, clip = clip,


### PR DESCRIPTION
Doesn't yet have any of the non-linear stuff, but it's already a big improvement.

ref https://github.com/tomasklaen/uosc/pull/665#issuecomment-1745887138

For comparison with the screenshot in the comment:
![image](https://github.com/tomasklaen/uosc/assets/8932183/381f8117-47c3-4fc0-bf94-e09b7da6efd2)
