### PR TITLE
fix: user-data/uosc/menu/type being nil means closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,8 +463,8 @@ Command {
 
 When `Command.value` is a string, it'll be passed to `mp.command(value)`. If it's a table (array) of strings, it'll be used as `mp.commandv(table.unpack(value))`. The same goes for `Menu.on_close` and `on_search`. `on_search` additionally appends the current search string as the last parameter.
 
-`Menu.type` is used to refer to this menu in `update-menu` and `close-menu`.
-While the menu is open this value will be available in `user-data/uosc/menu/type`. Keep in mind that `nil` is a valid value. If the menu is closed `mp.get_property_native()` will return an error as the second return value.
+`Menu.type` is used to refer to this menu in `update-menu` and `close-menu`.  
+While the menu is open this value will be available in `user-data/uosc/menu/type` and the `shared-script-properties` entry `uosc-menu-type`. If no type was provided, those will be set to `'undefined'`.
 
 `palette` specifies that this menu's primarily mode of interaction is through a search input. When enabled, search input will be visible at all times (doesn't have to be enabled and can't be disabled), and `title` will be used as input placeholder while search query is empty.
 

--- a/scripts/uosc/elements/Menu.lua
+++ b/scripts/uosc/elements/Menu.lua
@@ -112,7 +112,10 @@ function Menu:init(data, callback, opts)
 	self.drag_last_y = nil
 	self.is_dragging = false
 
-	mp.set_property_native('user-data/uosc/menu/type', self.type)
+	if utils.shared_script_property_set then
+		utils.shared_script_property_set('uosc-menu-type', self.type or 'undefined')
+	end
+	mp.set_property_native('user-data/uosc/menu/type', self.type or 'undefined')
 	self:update(data)
 
 	if self.mouse_nav then
@@ -132,7 +135,10 @@ function Menu:destroy()
 	self:disable_key_bindings()
 	self.is_closed = true
 	if not self.is_being_replaced then Elements.curtain:unregister('menu') end
-	mp.del_property('user-data/uosc/menu/type')
+	if utils.shared_script_property_set then
+		utils.shared_script_property_set('uosc-menu-type', nil)
+	end
+	mp.set_property_native('user-data/uosc/menu/type', nil)
 	if self.opts.on_close then self.opts.on_close() end
 end
 


### PR DESCRIPTION
`nil` being a valid menu type in the provided property was a mistake.
For backwards compatiblity we also set `shared-script-properties` now.

Fixes #672