### PR TITLE
fix: window border enable logic for non windows

### DIFF
--- a/scripts/uosc/elements/WindowBorder.lua
+++ b/scripts/uosc/elements/WindowBorder.lua
@@ -12,7 +12,7 @@ end
 
 function WindowBorder:decide_enabled()
 	self.enabled = options.window_border_size > 0 and not state.fullormaxed and not state.border
-	    and state.title_bar == false
+		and (state.platform ~= 'windows' or state.title_bar == false)
 	self.size = self.enabled and options.window_border_size or 0
 end
 


### PR DESCRIPTION
`top-bar` is only relevant on windows

Ref. https://github.com/tomasklaen/uosc/pull/643#issuecomment-1750853705