### PR TITLE
fix: volume slider crash when no audio

### DIFF
--- a/scripts/uosc/elements/Volume.lua
+++ b/scripts/uosc/elements/Volume.lua
@@ -201,7 +201,7 @@ function VolumeSlider:render()
 
 	-- Disabled stripes for no audio
 	if not state.has_audio then
-		local fg_100_path = create_nudged_path(self.border_size)
+		local fg_100_path = create_nudged_path(self.border_size, state.radius)
 		local texture_opts = {
 			size = 200, color = 'ffffff', opacity = visibility * 0.1, anchor_x = ax,
 			clip = '\\clip(' .. fg_100_path.scale .. ',' .. fg_100_path.text .. ')',


### PR DESCRIPTION
d2febcbd4709001f5db61b4d6befe545ab65d578 forgot the second parameter, resulting in a crash because it's nil.

![image](https://github.com/tomasklaen/uosc/assets/8932183/0fc71b93-3eaf-41cc-95ca-7492153b7524)
