### PR TITLE
feat: support for creating menu titles and separators in `input.conf`

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,11 @@ Submenu {
   title?: string;
   hint?: string;
   items: Item[];
+  bold?: boolean;
+  italic?: boolean;
+  align?: 'left'|'center'|'right';
+  muted?: boolean;
+  separator?: boolean;
   keep_open?: boolean;
   on_search?: string | string[];
   palette?: boolean;
@@ -453,19 +458,20 @@ Command {
   hint?: string;
   icon?: string;
   value: string | string[];
+  active?: integer;
+  selectable?: boolean;
   bold?: boolean;
   italic?: boolean;
   align?: 'left'|'center'|'right';
-  selectable?: boolean;
   muted?: boolean;
-  active?: integer;
+  separator?: boolean;
   keep_open?: boolean;
 }
 ```
 
 When `Command.value` is a string, it'll be passed to `mp.command(value)`. If it's a table (array) of strings, it'll be used as `mp.commandv(table.unpack(value))`. The same goes for `Menu.on_close` and `on_search`. `on_search` additionally appends the current search string as the last parameter.
 
-`Menu.type` is used to refer to this menu in `update-menu` and `close-menu`.  
+`Menu.type` is used to refer to this menu in `update-menu` and `close-menu`.
 While the menu is open this value will be available in `user-data/uosc/menu/type` and the `shared-script-properties` entry `uosc-menu-type`. If no type was provided, those will be set to `'undefined'`.
 
 `palette` specifies that this menu's primarily mode of interaction is through a search input. When enabled, search input will be visible at all times (doesn't have to be enabled and can't be disabled), and `title` will be used as input placeholder while search query is empty.

--- a/README.md
+++ b/README.md
@@ -348,6 +348,20 @@ Define a folder without defining any of its contents:
 #  ignore  #! Folder title >
 ```
 
+Define an un-selectable, muted, and italic title item by using `#` as key, and omitting the command:
+
+```
+#    #! Title
+#    #! Section > Title
+```
+
+Define a separator between previous and next items by doing the same, but using `---` as title:
+
+```
+#    #! ---
+#    #! Section > ---
+```
+
 Example context menu:
 
 This is the default pre-configured menu if none is defined in your `input.conf`, but with added shortcuts. To both pause & move the window with left mouse button, so that you can have the menu on the right one, enable `click_threshold` in `uosc.conf` (see default `uosc.conf` for example/docs).

--- a/scripts/uosc/elements/Menu.lua
+++ b/scripts/uosc/elements/Menu.lua
@@ -1,15 +1,15 @@
 local Element = require('elements/Element')
 
 -- Menu data structure accepted by `Menu:open(menu)`.
----@alias MenuData {id?: string; type?: string; title?: string; hint?: string; palette?: boolean; keep_open?: boolean; separator?: boolean; items?: MenuDataItem[]; selected_index?: integer; on_search?: string|string[]|fun(search_text: string); search_debounce?: number|string; search_submenus?: boolean; search_suggestion?: string}
+---@alias MenuData {id?: string; type?: string; title?: string; hint?: string; palette?: boolean; keep_open?: boolean; bold?: boolean; italic?: boolean; muted?: boolean; separator?: boolean; align?: 'left'|'center'|'right'; items?: MenuDataItem[]; selected_index?: integer; on_search?: string|string[]|fun(search_text: string); search_debounce?: number|string; search_submenus?: boolean; search_suggestion?: string}
 ---@alias MenuDataItem MenuDataValue|MenuData
----@alias MenuDataValue {title?: string; hint?: string; icon?: string; value: any; bold?: boolean; italic?: boolean; muted?: boolean; active?: boolean; keep_open?: boolean; separator?: boolean; selectable?: boolean; align?: 'left'|'center'|'right'}
+---@alias MenuDataValue {title?: string; hint?: string; icon?: string; value: any; active?: boolean; keep_open?: boolean; selectable?: boolean; bold?: boolean; italic?: boolean; muted?: boolean; separator?: boolean; align?: 'left'|'center'|'right'}
 ---@alias MenuOptions {mouse_nav?: boolean; on_open?: fun(); on_close?: fun(); on_back?: fun(); on_move_item?: fun(from_index: integer, to_index: integer, submenu_path: integer[]); on_delete_item?: fun(index: integer, submenu_path: integer[])}
 
 -- Internal data structure created from `Menu`.
----@alias MenuStack {id?: string; type?: string; title?: string; hint?: string; palette?: boolean, selected_index?: number; keep_open?: boolean; separator?: boolean; items: MenuStackItem[]; on_search?: string|string[]|fun(search_text: string); search_debounce?: number|string; search_submenus?: boolean; search_suggestion?: string; parent_menu?: MenuStack; submenu_path: integer[]; active?: boolean; width: number; height: number; top: number; scroll_y: number; scroll_height: number; title_width: number; hint_width: number; max_width: number; is_root?: boolean; fling?: Fling, search?: Search, ass_safe_title?: string}
+---@alias MenuStack {id?: string; type?: string; title?: string; hint?: string; palette?: boolean, selected_index?: number; keep_open?: boolean; bold?: boolean; italic?: boolean; muted?: boolean; separator?: boolean; align?: 'left'|'center'|'right'; items: MenuStackItem[]; on_search?: string|string[]|fun(search_text: string); search_debounce?: number|string; search_submenus?: boolean; search_suggestion?: string; parent_menu?: MenuStack; submenu_path: integer[]; active?: boolean; width: number; height: number; top: number; scroll_y: number; scroll_height: number; title_width: number; hint_width: number; max_width: number; is_root?: boolean; fling?: Fling, search?: Search, ass_safe_title?: string}
 ---@alias MenuStackItem MenuStackValue|MenuStack
----@alias MenuStackValue {title?: string; hint?: string; icon?: string; value: any; active?: boolean; bold?: boolean; italic?: boolean; muted?: boolean; keep_open?: boolean; separator?: boolean; selectable?: boolean; align?: 'left'|'center'|'right'; title_width: number; hint_width: number}
+---@alias MenuStackValue {title?: string; hint?: string; icon?: string; value: any; active?: boolean; keep_open?: boolean; selectable?: boolean; bold?: boolean; italic?: boolean; muted?: boolean; separator?: boolean; align?: 'left'|'center'|'right'; title_width: number; hint_width: number}
 ---@alias Fling {y: number, distance: number, time: number, easing: fun(x: number), duration: number, update_cursor?: boolean}
 ---@alias Search {query: string; timeout: unknown; min_top: number; max_width: number; source: {width: number; top: number; scroll_y: number; selected_index?: integer; items?: MenuDataItem[]}}
 

--- a/scripts/uosc/lib/menus.lua
+++ b/scripts/uosc/lib/menus.lua
@@ -346,17 +346,29 @@ do
 					else
 						if command == 'ignore' then break end
 						-- If command is already in menu, just append the key to it
-						if target_menu.items_by_command[command] then
+						if key ~= '#' and command ~= '' and target_menu.items_by_command[command] then
 							local hint = target_menu.items_by_command[command].hint
 							target_menu.items_by_command[command].hint = hint and hint .. ', ' .. key or key
 						else
-							local item = {
-								title = title_part,
-								hint = not is_dummy and key or nil,
-								value = command,
-							}
-							target_menu.items_by_command[command] = item
-							target_menu.items[#target_menu.items + 1] = item
+							-- Separator
+							if title_part:sub(1, 3) == '---' then
+								local last_item = target_menu.items[#target_menu.items]
+								if last_item then last_item.separator = true end
+							else
+								local item = {
+									title = title_part,
+									hint = not is_dummy and key or nil,
+									value = command,
+								}
+								if command == '' then
+									item.selectable = false
+									item.muted = true
+									item.italic = true
+								else
+									target_menu.items_by_command[command] = item
+								end
+								target_menu.items[#target_menu.items + 1] = item
+							end
 						end
 					end
 				end


### PR DESCRIPTION
When defining menu items in `input.conf`, it is now possible to add an un-selectable+muted+italic menu items by using `#` as key, and omitting the command:

```
#    #! Section > Title
```

![1](https://github.com/tomasklaen/uosc/assets/47283320/8c068472-a111-4e5d-aea1-eb835f5d9f5c)

You can also add a separator between previous and next item by using `---` as title:

```
#    #! Section > ---
```

![2](https://github.com/tomasklaen/uosc/assets/47283320/b8f4fa1a-f6e7-40e5-b8ba-50ef29170df8)

closes #69