### PR TITLE
fix: position update before mbtn_left down handler

### DIFF
--- a/scripts/uosc/lib/cursor.lua
+++ b/scripts/uosc/lib/cursor.lua
@@ -227,8 +227,8 @@ end
 
 function cursor:make_handler(event, cb)
 	return function(...)
-		self:trigger(event, ...)
 		call_maybe(cb, ...)
+		self:trigger(event, ...)
 	end
 end
 


### PR DESCRIPTION
Essentially same problem as in https://github.com/tomasklaen/uosc/pull/327.
Position update needs to happen _before_ the button event.
Broke with 8d85068b7c457c8e17599a350ecbb530988189f1 and I didn't notice until now because I don't use mpv with touch input on my laptop all that often.