### PR TITLE
fix: render after menu fling

### DIFF
--- a/scripts/uosc/elements/Menu.lua
+++ b/scripts/uosc/elements/Menu.lua
@@ -639,6 +639,7 @@ function Menu:handle_cursor_up()
 				duration = 0.5,
 				update_cursor = true,
 			}
+			request_render()
 		end
 	end
 	self.is_dragging = false


### PR DESCRIPTION
Most of the time flinging on a touch device looked like it didn't work, but it turns out that it simply didn't render.