### PR TITLE
Fix touch input handlers

### DIFF
--- a/scripts/uosc/elements/Button.lua
+++ b/scripts/uosc/elements/Button.lua
@@ -34,7 +34,7 @@ end
 function Button:render()
 	local visibility = self:get_visibility()
 	if visibility <= 0 then return end
-	cursor:on_main('primary_down', self, function() self:handle_cursor_down() end)
+	cursor:zone('primary_down', self, function() self:handle_cursor_down() end)
 
 	local ass = assdraw.ass_new()
 	local is_hover = self.proximity_raw == 0

--- a/scripts/uosc/elements/Button.lua
+++ b/scripts/uosc/elements/Button.lua
@@ -34,9 +34,7 @@ end
 function Button:render()
 	local visibility = self:get_visibility()
 	if visibility <= 0 then return end
-	if self.proximity_raw == 0 then
-		cursor.on_primary_down = function() self:handle_cursor_down() end
-	end
+	cursor:on_main('primary_down', self, function() self:handle_cursor_down() end)
 
 	local ass = assdraw.ass_new()
 	local is_hover = self.proximity_raw == 0

--- a/scripts/uosc/elements/Menu.lua
+++ b/scripts/uosc/elements/Menu.lua
@@ -1066,10 +1066,10 @@ function Menu:render()
 	end
 
 	local display_rect = {ax = 0, ay = 0, bx = display.width, by = display.height}
-	cursor:on_main('primary_down', display_rect, self:create_action(function() self:handle_cursor_down() end))
-	cursor:on_main('primary_up', display_rect, self:create_action(function() self:handle_cursor_up() end))
-	cursor:on_main('wheel_down', self, function() self:handle_wheel_down() end)
-	cursor:on_main('wheel_up', self, function() self:handle_wheel_up() end)
+	cursor:zone('primary_down', display_rect, self:create_action(function() self:handle_cursor_down() end))
+	cursor:zone('primary_up', display_rect, self:create_action(function() self:handle_cursor_up() end))
+	cursor:zone('wheel_down', self, function() self:handle_wheel_down() end)
+	cursor:zone('wheel_up', self, function() self:handle_wheel_up() end)
 
 	local ass = assdraw.ass_new()
 	local spacing = self.item_padding
@@ -1100,7 +1100,7 @@ function Menu:render()
 		})
 
 		if is_parent then
-			cursor:on_main('primary_down', menu_rect, self:create_action(function() self:slide_in_menu(menu, x) end))
+			cursor:zone('primary_down', menu_rect, self:create_action(function() self:slide_in_menu(menu, x) end))
 		end
 
 		-- Draw submenu if selected
@@ -1108,7 +1108,7 @@ function Menu:render()
 		local submenu_is_hovered = false
 		if current_item and current_item.items then
 			submenu_rect = draw_menu(current_item, menu_rect.bx + self.gap, 1)
-			cursor:on_main('primary_down', submenu_rect, self:create_action(function()
+			cursor:zone('primary_down', submenu_rect, self:create_action(function()
 				self:open_selected_item({preselect_first_item = false})
 			end))
 		end
@@ -1242,7 +1242,7 @@ function Menu:render()
 
 			-- Do nothing when user clicks title
 			if is_current then
-				cursor:on_main('primary_down', rect, function() end)
+				cursor:zone('primary_down', rect, function() end)
 			end
 
 			-- Title
@@ -1252,7 +1252,7 @@ function Menu:render()
 				local icon_rect = {ax = rect.ax, ay = rect.ay, bx = ax + icon_size + spacing * 1.5, by = rect.by}
 
 				if is_current and requires_submit then
-					cursor:on_main('primary_down', icon_rect, function() self:search_submit() end)
+					cursor:zone('primary_down', icon_rect, function() self:search_submit() end)
 					if get_point_to_rectangle_proximity(cursor, icon_rect) == 0 then
 						icon_opacity = menu_opacity
 					end

--- a/scripts/uosc/elements/Speed.lua
+++ b/scripts/uosc/elements/Speed.lua
@@ -105,18 +105,13 @@ function Speed:render()
 
 	if opacity <= 0 then return end
 
-	if self.proximity_raw == 0 then
-		cursor.on_primary_down = function()
-			self:handle_cursor_down()
-			cursor.on_primary_up = function() self:handle_cursor_up() end
-		end
-		cursor.on_secondary_down = function() mp.set_property_native('speed', 1) end
-		cursor.on_wheel_down = function() self:handle_wheel_down() end
-		cursor.on_wheel_up = function() self:handle_wheel_up() end
-	end
-	if self.dragging then
-		cursor.on_primary_up = function() self:handle_cursor_up() end
-	end
+	cursor:on_main('primary_down', self, function()
+		self:handle_cursor_down()
+		cursor:once('primary_up', function() self:handle_cursor_up() end)
+	end)
+	cursor:on_main('secondary_down', self, function() mp.set_property_native('speed', 1) end)
+	cursor:on_main('wheel_down', self, function() self:handle_wheel_down() end)
+	cursor:on_main('wheel_up', self, function() self:handle_wheel_up() end)
 
 	local ass = assdraw.ass_new()
 

--- a/scripts/uosc/elements/Speed.lua
+++ b/scripts/uosc/elements/Speed.lua
@@ -105,13 +105,13 @@ function Speed:render()
 
 	if opacity <= 0 then return end
 
-	cursor:on_main('primary_down', self, function()
+	cursor:zone('primary_down', self, function()
 		self:handle_cursor_down()
 		cursor:once('primary_up', function() self:handle_cursor_up() end)
 	end)
-	cursor:on_main('secondary_down', self, function() mp.set_property_native('speed', 1) end)
-	cursor:on_main('wheel_down', self, function() self:handle_wheel_down() end)
-	cursor:on_main('wheel_up', self, function() self:handle_wheel_up() end)
+	cursor:zone('secondary_down', self, function() mp.set_property_native('speed', 1) end)
+	cursor:zone('wheel_down', self, function() self:handle_wheel_down() end)
+	cursor:zone('wheel_up', self, function() self:handle_wheel_up() end)
 
 	local ass = assdraw.ass_new()
 

--- a/scripts/uosc/elements/Timeline.lua
+++ b/scripts/uosc/elements/Timeline.lua
@@ -158,12 +158,14 @@ function Timeline:render()
 	if self.proximity_raw == 0 then
 		self.is_hovered = true
 	end
-	cursor:zone('primary_down', self, function()
-		self:handle_cursor_down()
-		cursor:once('primary_up', function() self:handle_cursor_up() end)
-	end)
-	cursor:zone('wheel_down', self, function() self:handle_wheel_down() end)
-	cursor:zone('wheel_up', self, function() self:handle_wheel_up() end)
+	if visibility > 0 then
+		cursor:zone('primary_down', self, function()
+			self:handle_cursor_down()
+			cursor:once('primary_up', function() self:handle_cursor_up() end)
+		end)
+		cursor:zone('wheel_down', self, function() self:handle_wheel_down() end)
+		cursor:zone('wheel_up', self, function() self:handle_wheel_up() end)
+	end
 
 	local ass = assdraw.ass_new()
 
@@ -297,9 +299,11 @@ function Timeline:render()
 				for i, chapter in ipairs(state.chapters) do
 					if chapter ~= hovered_chapter then draw_chapter(chapter.time, diamond_radius) end
 					local circle = {point = {x = t2x(chapter.time), y = fay - 1}, r = diamond_radius_hovered}
-					cursor:zone('primary_down', circle, function()
-						mp.commandv('seek', chapter.time, 'absolute+exact')
-					end)
+					if visibility > 0 then
+						cursor:zone('primary_down', circle, function()
+							mp.commandv('seek', chapter.time, 'absolute+exact')
+						end)
+					end
 				end
 
 				-- Render hovered chapter above others

--- a/scripts/uosc/elements/Timeline.lua
+++ b/scripts/uosc/elements/Timeline.lua
@@ -158,12 +158,12 @@ function Timeline:render()
 	if self.proximity_raw == 0 then
 		self.is_hovered = true
 	end
-	cursor:on_main('primary_down', self, function()
+	cursor:zone('primary_down', self, function()
 		self:handle_cursor_down()
 		cursor:once('primary_up', function() self:handle_cursor_up() end)
 	end)
-	cursor:on_main('wheel_down', self, function() self:handle_wheel_down() end)
-	cursor:on_main('wheel_up', self, function() self:handle_wheel_up() end)
+	cursor:zone('wheel_down', self, function() self:handle_wheel_down() end)
+	cursor:zone('wheel_up', self, function() self:handle_wheel_up() end)
 
 	local ass = assdraw.ass_new()
 
@@ -297,7 +297,7 @@ function Timeline:render()
 				for i, chapter in ipairs(state.chapters) do
 					if chapter ~= hovered_chapter then draw_chapter(chapter.time, diamond_radius) end
 					local circle = {point = {x = t2x(chapter.time), y = fay - 1}, r = diamond_radius_hovered}
-					cursor:on_main('primary_down', circle, function()
+					cursor:zone('primary_down', circle, function()
 						mp.commandv('seek', chapter.time, 'absolute+exact')
 					end)
 				end

--- a/scripts/uosc/elements/Timeline.lua
+++ b/scripts/uosc/elements/Timeline.lua
@@ -290,21 +290,16 @@ function Timeline:render()
 						if cursor_chapter_delta <= diamond_radius_hovered and cursor_chapter_delta < closest_delta then
 							hovered_chapter, closest_delta = chapter, cursor_chapter_delta
 							self.is_hovered = true
-							local rect = {
-								ax = chapter_x - diamond_radius_hovered,
-								ay = chapter_y - diamond_radius_hovered,
-								bx = chapter_x + diamond_radius_hovered,
-								by = chapter_y + diamond_radius_hovered,
-							}
-							cursor:on_main('primary_down', rect, function()
-								mp.commandv('seek', hovered_chapter.time, 'absolute+exact')
-							end)
 						end
 					end
 				end
 
 				for i, chapter in ipairs(state.chapters) do
 					if chapter ~= hovered_chapter then draw_chapter(chapter.time, diamond_radius) end
+					local circle = {point = {x = t2x(chapter.time), y = fay - 1}, r = diamond_radius_hovered}
+					cursor:on_main('primary_down', circle, function()
+						mp.commandv('seek', chapter.time, 'absolute+exact')
+					end)
 				end
 
 				-- Render hovered chapter above others

--- a/scripts/uosc/elements/TopBar.lua
+++ b/scripts/uosc/elements/TopBar.lua
@@ -29,7 +29,7 @@ function TopBarButton:render()
 	if self.proximity_raw == 0 then
 		ass:rect(self.ax, self.ay, self.bx, self.by, {color = self.background, opacity = visibility})
 	end
-	cursor:on_main('primary_down', self, function() self:handle_cursor_down() end)
+	cursor:zone('primary_down', self, function() self:handle_cursor_down() end)
 
 	local width, height = self.bx - self.ax, self.by - self.ay
 	local icon_size = math.min(width, height) * 0.5
@@ -219,7 +219,7 @@ function TopBar:render()
 			title_ax = rect.bx + bg_margin
 
 			-- Click action
-			cursor:on_main('primary_down', rect, function() mp.command('script-binding uosc/playlist') end)
+			cursor:zone('primary_down', rect, function() mp.command('script-binding uosc/playlist') end)
 		end
 
 		-- Skip rendering titles if there's not enough horizontal space
@@ -241,7 +241,7 @@ function TopBar:render()
 				local title_rect = {ax = title_ax, ay = title_ay, bx = bx, by = by}
 
 				if options.top_bar_alt_title_place == 'toggle' then
-					cursor:on_main('primary_down', title_rect, function() self:toggle_title() end)
+					cursor:zone('primary_down', title_rect, function() self:toggle_title() end)
 					if get_point_to_rectangle_proximity(cursor, title_rect) == 0 then
 						cursor.allow_dragging = true
 					end
@@ -304,7 +304,7 @@ function TopBar:render()
 				title_ay = rect.by + 1
 
 				-- Click action
-				cursor:on_main('primary_down', rect, function() mp.command('script-binding uosc/chapters') end)
+				cursor:zone('primary_down', rect, function() mp.command('script-binding uosc/chapters') end)
 			end
 		end
 		self.title_by = title_ay - 1

--- a/scripts/uosc/elements/TopBar.lua
+++ b/scripts/uosc/elements/TopBar.lua
@@ -242,9 +242,6 @@ function TopBar:render()
 
 				if options.top_bar_alt_title_place == 'toggle' then
 					cursor:zone('primary_down', title_rect, function() self:toggle_title() end)
-					if get_point_to_rectangle_proximity(cursor, title_rect) == 0 then
-						cursor.allow_dragging = true
-					end
 				end
 
 				ass:rect(title_rect.ax, title_rect.ay, title_rect.bx, title_rect.by, {

--- a/scripts/uosc/elements/TopBar.lua
+++ b/scripts/uosc/elements/TopBar.lua
@@ -28,8 +28,8 @@ function TopBarButton:render()
 	-- Background on hover
 	if self.proximity_raw == 0 then
 		ass:rect(self.ax, self.ay, self.bx, self.by, {color = self.background, opacity = visibility})
-		cursor.on_primary_down = function() self:handle_cursor_down() end
 	end
+	cursor:on_main('primary_down', self, function() self:handle_cursor_down() end)
 
 	local width, height = self.bx - self.ax, self.by - self.ay
 	local icon_size = math.min(width, height) * 0.5
@@ -219,9 +219,7 @@ function TopBar:render()
 			title_ax = rect.bx + bg_margin
 
 			-- Click action
-			if get_point_to_rectangle_proximity(cursor, rect) == 0 then
-				cursor.on_primary_down = function() mp.command('script-binding uosc/playlist') end
-			end
+			cursor:on_main('primary_down', rect, function() mp.command('script-binding uosc/playlist') end)
 		end
 
 		-- Skip rendering titles if there's not enough horizontal space
@@ -242,10 +240,11 @@ function TopBar:render()
 				local by = self.by - bg_margin
 				local title_rect = {ax = title_ax, ay = title_ay, bx = bx, by = by}
 
-				if options.top_bar_alt_title_place == 'toggle'
-					and get_point_to_rectangle_proximity(cursor, title_rect) == 0 then
-					cursor.on_primary_down = function() self:toggle_title() end
-					cursor.allow_dragging = true
+				if options.top_bar_alt_title_place == 'toggle' then
+					cursor:on_main('primary_down', title_rect, function() self:toggle_title() end)
+					if get_point_to_rectangle_proximity(cursor, title_rect) == 0 then
+						cursor.allow_dragging = true
+					end
 				end
 
 				ass:rect(title_rect.ax, title_rect.ay, title_rect.bx, title_rect.by, {
@@ -305,9 +304,7 @@ function TopBar:render()
 				title_ay = rect.by + 1
 
 				-- Click action
-				if get_point_to_rectangle_proximity(cursor, rect) == 0 then
-					cursor.on_primary_down = function() mp.command('script-binding uosc/chapters') end
-				end
+				cursor:on_main('primary_down', rect, function() mp.command('script-binding uosc/chapters') end)
 			end
 		end
 		self.title_by = title_ay - 1

--- a/scripts/uosc/elements/Volume.lua
+++ b/scripts/uosc/elements/Volume.lua
@@ -57,20 +57,13 @@ function VolumeSlider:render()
 
 	if width <= 0 or height <= 0 or visibility <= 0 then return end
 
-	if self.proximity_raw == 0 then
-		cursor.on_primary_down = function()
-			self.pressed = true
-			self:set_from_cursor()
-			cursor.on_primary_up = function() self.pressed = false end
-		end
-		cursor.on_wheel_down = function() self:handle_wheel_down() end
-		cursor.on_wheel_up = function() self:handle_wheel_up() end
-	end
-	if self.pressed then
-		cursor.on_primary_up = function()
-			self.pressed = false
-		end
-	end
+	cursor:on_main('primary_down', self, function()
+		self.pressed = true
+		self:set_from_cursor()
+		cursor:once('primary_up', function() self.pressed = false end)
+	end)
+	cursor:on_main('wheel_down', self, function() self:handle_wheel_down() end)
+	cursor:on_main('wheel_up', self, function() self:handle_wheel_up() end)
 
 	local ass = assdraw.ass_new()
 	local nudge_y, nudge_size = self.draw_nudge and self.nudge_y or -math.huge, self.nudge_size
@@ -256,18 +249,14 @@ function Volume:render()
 	if visibility <= 0 then return end
 
 	-- Reset volume on secondary click
-	if self.proximity_raw == 0 then
-		cursor.on_secondary_down = function()
-			mp.set_property_native('mute', false)
-			mp.set_property_native('volume', 100)
-		end
-	end
+	cursor:on_main('secondary_down', self, function()
+		mp.set_property_native('mute', false)
+		mp.set_property_native('volume', 100)
+	end)
 
 	-- Mute button
 	local mute_rect = {ax = self.ax, ay = self.mute_ay, bx = self.bx, by = self.by}
-	if get_point_to_rectangle_proximity(cursor, mute_rect) == 0 then
-		cursor.on_primary_down = function() mp.commandv('cycle', 'mute') end
-	end
+	cursor:on_main('primary_down', mute_rect, function() mp.commandv('cycle', 'mute') end)
 	local ass = assdraw.ass_new()
 	local width_half = (mute_rect.bx - mute_rect.ax) / 2
 	local height_half = (mute_rect.by - mute_rect.ay) / 2

--- a/scripts/uosc/elements/Volume.lua
+++ b/scripts/uosc/elements/Volume.lua
@@ -57,13 +57,13 @@ function VolumeSlider:render()
 
 	if width <= 0 or height <= 0 or visibility <= 0 then return end
 
-	cursor:on_main('primary_down', self, function()
+	cursor:zone('primary_down', self, function()
 		self.pressed = true
 		self:set_from_cursor()
 		cursor:once('primary_up', function() self.pressed = false end)
 	end)
-	cursor:on_main('wheel_down', self, function() self:handle_wheel_down() end)
-	cursor:on_main('wheel_up', self, function() self:handle_wheel_up() end)
+	cursor:zone('wheel_down', self, function() self:handle_wheel_down() end)
+	cursor:zone('wheel_up', self, function() self:handle_wheel_up() end)
 
 	local ass = assdraw.ass_new()
 	local nudge_y, nudge_size = self.draw_nudge and self.nudge_y or -math.huge, self.nudge_size
@@ -249,14 +249,14 @@ function Volume:render()
 	if visibility <= 0 then return end
 
 	-- Reset volume on secondary click
-	cursor:on_main('secondary_down', self, function()
+	cursor:zone('secondary_down', self, function()
 		mp.set_property_native('mute', false)
 		mp.set_property_native('volume', 100)
 	end)
 
 	-- Mute button
 	local mute_rect = {ax = self.ax, ay = self.mute_ay, bx = self.bx, by = self.by}
-	cursor:on_main('primary_down', mute_rect, function() mp.commandv('cycle', 'mute') end)
+	cursor:zone('primary_down', mute_rect, function() mp.commandv('cycle', 'mute') end)
 	local ass = assdraw.ass_new()
 	local width_half = (mute_rect.bx - mute_rect.ax) / 2
 	local height_half = (mute_rect.by - mute_rect.ay) / 2

--- a/scripts/uosc/lib/cursor.lua
+++ b/scripts/uosc/lib/cursor.lua
@@ -3,7 +3,6 @@ local cursor = {
 	y = math.huge,
 	hidden = true,
 	hover_raw = false,
-	allow_dragging = true,
 	-- Event handlers that are only fired on cursor, bound during render loop. Guidelines:
 	-- - element activations (clicks) go to `primary_down` handler
 	-- - `primary_up` is only for clearing dragging/swiping, and prevents autohide when bound
@@ -29,7 +28,6 @@ local cursor = {
 	first_real_mouse_move_received = false,
 	history = CircularBuffer:new(10),
 	-- Enables pointer key group captures needed by handlers (called at the end of each render)
-	allow_dragging_enabled = nil,
 	mbtn_left_dbl_enabled = nil,
 	mbtn_right_enabled = nil,
 	wheel_enabled = nil,
@@ -46,7 +44,6 @@ function cursor:clear_zones()
 	for _, handlers in pairs(self.zone_handlers) do
 		itable_clear(handlers)
 	end
-	self.allow_dragging = true
 end
 
 ---@param event string
@@ -133,10 +130,6 @@ function cursor:decide_keybinds()
 	local enable_mbtn_left_dbl = self:has_handler('primary_down') or self:has_handler('primary_up')
 	local enable_mbtn_right = self:has_handler('secondary_down') or self:has_handler('secondary_up')
 	local enable_wheel = self:has_handler('wheel_down') or self:has_handler('wheel_up')
-	if self.allow_dragging ~= self.allow_dragging_enabled then
-		mp.enable_key_bindings('mbtn_left', 'allow-vo-dragging')
-		self.allow_dragging_enabled = self.allow_dragging
-	end
 	if enable_mbtn_left_dbl ~= self.mbtn_left_dbl_enabled then
 		mp[(enable_mbtn_left_dbl and 'enable' or 'disable') .. '_key_bindings']('mbtn_left_dbl')
 		self.mbtn_left_dbl_enabled = enable_mbtn_left_dbl
@@ -295,6 +288,7 @@ mp.set_key_bindings({
 		end),
 	},
 }, 'mbtn_left', 'force')
+mp.add_timeout(0, function() mp.enable_key_bindings('mbtn_left', 'allow-vo-dragging') end)
 mp.set_key_bindings({
 	{'mbtn_left_dbl', 'ignore'},
 }, 'mbtn_left_dbl', 'force')

--- a/scripts/uosc/lib/cursor.lua
+++ b/scripts/uosc/lib/cursor.lua
@@ -7,7 +7,7 @@ local cursor = {
 	-- Event handlers that are only fired on cursor, bound during render loop. Guidelines:
 	-- - element activations (clicks) go to `primary_down` handler
 	-- - `primary_up` is only for clearing dragging/swiping, and prevents autohide when bound
-	---@type {[string]: {rect: Rect; handler: fun()}[]}
+	---@type {[string]: {hitbox: Rect|{point: Point, r: number}; handler: fun()}[]}
 	main_handlers = {
 		primary_down = {},
 		primary_up = {},
@@ -53,15 +53,18 @@ function cursor:find_main_handler(event)
 	local area_handlers = self.main_handlers[event]
 	for i = #area_handlers, 1, -1 do
 		local area_handler = area_handlers[i]
-		if get_point_to_rectangle_proximity(self, area_handler.rect) == 0 then
+		local hitbox = area_handler.hitbox
+		print(utils.to_string(hitbox))
+		if (hitbox.r and get_point_to_point_proximity(self, hitbox.point) <= hitbox.r) or
+			(not hitbox.r and get_point_to_rectangle_proximity(self, hitbox) == 0) then
 			return area_handler.handler
 		end
 	end
 end
 
-function cursor:on_main(event, rect, callback)
+function cursor:on_main(event, hitbox, callback)
 	local area_handlers = self.main_handlers[event]
-	area_handlers[#area_handlers + 1] = {rect = rect, handler = callback}
+	area_handlers[#area_handlers + 1] = {hitbox = hitbox, handler = callback}
 end
 
 -- Binds a cursor event handler.

--- a/scripts/uosc/lib/cursor.lua
+++ b/scripts/uosc/lib/cursor.lua
@@ -104,14 +104,18 @@ function cursor:trigger(event, ...)
 	if zone_handler then
 		call_maybe(zone_handler, ...)
 	elseif event == 'primary_down' or event == 'primary_up' then
-		-- forward to other scripts
+		-- forward the event if we don't have any use for it
 		local active = find_active_keybindings('MBTN_LEFT')
 		if active then
 			if active.owner then
+				-- binding belongs to other script, so make it look like regular key event
+				-- mouse bindings are simple, other keys would require repeat and pressed handling
+				-- which can't be done with mp.set_key_bindings(), but is possible with mp.add_key_binding()
 				local state = event == 'primary_up' and 'um' or 'dm'
 				local name = active.cmd:sub(active.cmd:find('/') + 1, -1)
-				mp.commandv('script-message-to', active.owner, 'key-binding', name, state, 'MBTN_LEFT', '')
+				mp.commandv('script-message-to', active.owner, 'key-binding', name, state, 'MBTN_LEFT')
 			elseif event == 'primary_down' then
+				-- input.conf binding
 				mp.command(active.cmd)
 			end
 		end

--- a/scripts/uosc/lib/cursor.lua
+++ b/scripts/uosc/lib/cursor.lua
@@ -293,7 +293,7 @@ mp.set_key_bindings({
 		end),
 	},
 }, 'mbtn_left', 'force')
-mp.add_timeout(0, function() mp.enable_key_bindings('mbtn_left', 'allow-vo-dragging') end)
+mp.add_timeout(0, function() mp.enable_key_bindings('mbtn_left', 'allow-vo-dragging+allow-hide-cursor') end)
 mp.set_key_bindings({
 	{'mbtn_left_dbl', 'ignore'},
 }, 'mbtn_left_dbl', 'force')

--- a/scripts/uosc/lib/cursor.lua
+++ b/scripts/uosc/lib/cursor.lua
@@ -126,11 +126,13 @@ function cursor:trigger(event, ...)
 	self:queue_autohide() -- refresh cursor autohide timer
 end
 
+---Checks if there are any handlers for the current cursor position
 ---@param name string
 function cursor:has_handler(name)
 	return self:find_zone_handler(name) ~= nil or #self.handlers[name] > 0
 end
 
+---Checks if there are any handlers at all
 ---@param name string
 function cursor:has_any_handler(name)
 	return #self.zone_handlers[name] > 0 or #self.handlers[name] > 0

--- a/scripts/uosc/lib/cursor.lua
+++ b/scripts/uosc/lib/cursor.lua
@@ -30,6 +30,7 @@ local cursor = {
 	history = CircularBuffer:new(10),
 	-- Enables pointer key group captures needed by handlers (called at the end of each render)
 	allow_dragging_enabled = nil,
+	mbtn_left_dbl_enabled = nil,
 	mbtn_right_enabled = nil,
 	wheel_enabled = nil,
 }
@@ -129,11 +130,16 @@ end
 
 -- Enables or disables keybinding groups based on what event listeners are bound.
 function cursor:decide_keybinds()
+	local enable_mbtn_left_dbl = self:has_handler('primary_down') or self:has_handler('primary_up')
 	local enable_mbtn_right = self:has_handler('secondary_down') or self:has_handler('secondary_up')
 	local enable_wheel = self:has_handler('wheel_down') or self:has_handler('wheel_up')
 	if self.allow_dragging ~= self.allow_dragging_enabled then
 		mp.enable_key_bindings('mbtn_left', 'allow-vo-dragging')
 		self.allow_dragging_enabled = self.allow_dragging
+	end
+	if enable_mbtn_left_dbl ~= self.mbtn_left_dbl_enabled then
+		mp[(enable_mbtn_left_dbl and 'enable' or 'disable') .. '_key_bindings']('mbtn_left_dbl')
+		self.mbtn_left_dbl_enabled = enable_mbtn_left_dbl
 	end
 	if enable_mbtn_right ~= self.mbtn_right_enabled then
 		mp[(enable_mbtn_right and 'enable' or 'disable') .. '_key_bindings']('mbtn_right')
@@ -288,8 +294,10 @@ mp.set_key_bindings({
 			handle_mouse_pos(nil, mp.get_property_native('mouse-pos'))
 		end),
 	},
-	-- {'mbtn_left_dbl', 'ignore'},
 }, 'mbtn_left', 'force')
+mp.set_key_bindings({
+	{'mbtn_left_dbl', 'ignore'},
+}, 'mbtn_left_dbl', 'force')
 mp.set_key_bindings({
 	{'mbtn_right', cursor:make_handler('secondary_up'), cursor:make_handler('secondary_down')},
 }, 'mbtn_right', 'force')

--- a/scripts/uosc/lib/menus.lua
+++ b/scripts/uosc/lib/menus.lua
@@ -402,21 +402,8 @@ end
 
 -- Adapted from `stats.lua`
 function get_input_items()
-	local bindings = mp.get_property_native('input-bindings', {})
-	local active = {} -- map: key-name -> bind-info
 	local items = {}
-
-	-- Find active keybinds
-	for _, bind in pairs(bindings) do
-		if bind.priority >= 0 and (
-				not active[bind.key]
-				or (active[bind.key].is_weak and not bind.is_weak)
-				or (bind.is_weak == active[bind.key].is_weak and bind.priority > active[bind.key].priority)
-			)
-		then
-			active[bind.key] = bind
-		end
-	end
+	local active = find_active_keybindings()
 
 	-- Convert to menu items
 	for _, bind in pairs(active) do

--- a/scripts/uosc/lib/std.lua
+++ b/scripts/uosc/lib/std.lua
@@ -269,7 +269,6 @@ CircularBuffer = class()
 function CircularBuffer:new(max_size) return Class.new(self, max_size) --[[@as CircularBuffer]] end
 function CircularBuffer:init(max_size)
 	self.max_size = max_size
-	self.size = 0
 	self.pos = 0
 	self.data = {}
 end
@@ -277,15 +276,14 @@ end
 function CircularBuffer:insert(item)
 	self.pos = self.pos % self.max_size + 1
 	self.data[self.pos] = item
-	if self.size < self.max_size then self.size = self.size + 1 end
 end
 
 function CircularBuffer:get(i)
-	return i <= self.size and self.data[(self.pos + i - 1) % self.size + 1] or nil
+	return i <= #self.data and self.data[(self.pos + i - 1) % #self.data + 1] or nil
 end
 
 local function iter(self, i)
-	if i == self.size then return nil end
+	if i == #self.data then return nil end
 	i = i + 1
 	return i, self:get(i)
 end
@@ -301,7 +299,7 @@ local function iter_rev(self, i)
 end
 
 function CircularBuffer:iter_rev()
-	return iter_rev, self, self.size + 1
+	return iter_rev, self, #self.data + 1
 end
 
 function CircularBuffer:head()
@@ -309,12 +307,11 @@ function CircularBuffer:head()
 end
 
 function CircularBuffer:tail()
-	if self.size < 1 then return nil end
-	return self.data[self.pos % self.size + 1]
+	if #self.data < 1 then return nil end
+	return self.data[self.pos % #self.data + 1]
 end
 
 function CircularBuffer:clear()
-	for i = self.size, 1, -1 do self.data[i] = nil end
-	self.size = 0
+	itable_clear(self.data)
 	self.pos = 0
 end

--- a/scripts/uosc/lib/std.lua
+++ b/scripts/uosc/lib/std.lua
@@ -258,7 +258,7 @@ function Class:new(...)
 	object:init(...)
 	return object
 end
-function Class:init() end
+function Class:init(...) end
 function Class:destroy() end
 
 function class(parent) return setmetatable({}, {__index = parent or Class}) end

--- a/scripts/uosc/lib/std.lua
+++ b/scripts/uosc/lib/std.lua
@@ -173,6 +173,10 @@ function itable_append(target, source)
 	return target
 end
 
+function itable_clear(itable)
+	for i = #itable, 1, -1 do itable[i] = nil end
+end
+
 ---@generic T
 ---@param input table<T, any>
 ---@return T[]

--- a/scripts/uosc/lib/utils.lua
+++ b/scripts/uosc/lib/utils.lua
@@ -705,11 +705,7 @@ function find_active_keybindings(key)
 			active[bind.key] = bind
 		end
 	end
-	if key then
-		return active[key]
-	else
-		return active
-	end
+	return not key and active or active[key]
 end
 
 --[[ RENDERING ]]

--- a/scripts/uosc/lib/utils.lua
+++ b/scripts/uosc/lib/utils.lua
@@ -695,7 +695,7 @@ function render()
 	if not display.initialized then return end
 	state.render_last_time = mp.get_time()
 
-	cursor:reset_main_handlers()
+	cursor:clear_zones()
 
 	-- Actual rendering
 	local ass = assdraw.ass_new()

--- a/scripts/uosc/lib/utils.lua
+++ b/scripts/uosc/lib/utils.lua
@@ -751,6 +751,8 @@ function render()
 		end
 	end
 
+	cursor:decide_keybinds()
+
 	-- submit
 	if osd.res_x == display.width and osd.res_y == display.height and osd.data == ass.text then
 		return
@@ -762,7 +764,6 @@ function render()
 	osd.z = 2000
 	osd:update()
 
-	cursor:decide_keybinds()
 	update_margins()
 end
 

--- a/scripts/uosc/lib/utils.lua
+++ b/scripts/uosc/lib/utils.lua
@@ -689,6 +689,29 @@ function serialize_chapters(chapters)
 	return chapters
 end
 
+---Find all active key bindings or the active key binding for key
+---@param key string|nil
+---@return {[string]: table}|table
+function find_active_keybindings(key)
+	local bindings = mp.get_property_native('input-bindings', {})
+	local active = {} -- map: key-name -> bind-info
+	for _, bind in pairs(bindings) do
+		if bind.owner ~= 'uosc' and bind.priority >= 0 and (not key or bind.key == key) and (
+				not active[bind.key]
+				or (active[bind.key].is_weak and not bind.is_weak)
+				or (bind.is_weak == active[bind.key].is_weak and bind.priority > active[bind.key].priority)
+			)
+		then
+			active[bind.key] = bind
+		end
+	end
+	if key then
+		return active[key]
+	else
+		return active
+	end
+end
+
 --[[ RENDERING ]]
 
 function render()

--- a/scripts/uosc/lib/utils.lua
+++ b/scripts/uosc/lib/utils.lua
@@ -751,8 +751,6 @@ function render()
 		end
 	end
 
-	cursor:decide_keybinds()
-
 	-- submit
 	if osd.res_x == display.width and osd.res_y == display.height and osd.data == ass.text then
 		return
@@ -764,6 +762,7 @@ function render()
 	osd.z = 2000
 	osd:update()
 
+	cursor:decide_keybinds()
 	update_margins()
 end
 


### PR DESCRIPTION
This not only prevents the problem described in the issue, but it also allows all rendered elements to be tapped, even when a different element was hovered on last render.

It still requires hovering an element before being able to tap anything, but that's probably unavoidable without always having mbtn events registered. Registering clicks on mbtn up as well we mbtn down could alleviate that problem for buttons, but that wouldn't work universally.

Known problems
* `cursor.allow_dragging = true` in the top bar only works when the cursor was already on the top bar on the last render, not a big deal
* ~~timeline chapter markers require hover before being clickable because of their round hitbox. We can either make the hitbox squares or make `cursor:find_main_handler()` able to deal with circular hitboxes.~~

Fixes #706