### PR TITLE
fix: touch events firing before handlers are bound

### DIFF
--- a/scripts/uosc/lib/utils.lua
+++ b/scripts/uosc/lib/utils.lua
@@ -733,6 +733,7 @@ function render()
 	end
 
 	cursor:decide_keybinds()
+	cursor:release_main_queue()
 
 	-- submit
 	if osd.res_x == display.width and osd.res_y == display.height and osd.data == ass.text then


### PR DESCRIPTION
Implements an event queue for main `*_down` events bound during render ticks.

All `*_down` events are delayed until the end of the next render tick.

All `*_up` events are ensured to be triggered after their `*_down` counterparts if there's one in the queue.

And all events are deduplicated so there's not more than one of the same type in the queue in sequence, although it's hard to imagine how that could happen.

closes #706