### PR TITLE
feat: broadcast uosc version as early as possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,19 @@ esc         quit #! Quit
 
 To see all the commands you can bind keys or menu items to, refer to [mpv's list of input commands documentation](https://mpv.io/manual/master/#list-of-input-commands).
 
+## Messages
+
+### `uosc-version <version>`
+
+Broadcasts the uosc version during script initialization. Useful if you want to detect that uosc is installed. Example:
+
+```lua
+-- Register response handler
+mp.register_script_message('uosc-version', function(version)
+  print('uosc version', version)
+end)
+```
+
 ## Message handlers
 
 **uosc** listens on some messages that can be sent with `script-message-to uosc` command. Example:

--- a/README.md
+++ b/README.md
@@ -414,20 +414,6 @@ To see all the commands you can bind keys or menu items to, refer to [mpv's list
 R    script-message-to uosc show-submenu "Utils > Aspect ratio"
 ```
 
-### `get-version <script_id>`
-
-Tells uosc to send it's version to `<script_id>` script. Useful if you want to detect that uosc is installed. Example:
-
-```lua
--- Register response handler
-mp.register_script_message('uosc-version', function(version)
-  print('uosc version', version)
-end)
-
--- Ask for version
-mp.commandv('script-message-to', 'uosc', 'get-version', mp.get_script_name())
-```
-
 ### `show-submenu <menu_id>`, `show-submenu-blurred <menu_id>`
 
 Opens one of the submenus defined in `input.conf` (read on how to build those in the Menu documentation above). To prevent 1st item being preselected, use `show-submenu-blurred` instead.

--- a/scripts/uosc/main.lua
+++ b/scripts/uosc/main.lua
@@ -1,5 +1,6 @@
 --[[ uosc 4.7.0 - 2023-Apr-15 | https://github.com/tomasklaen/uosc ]]
 local uosc_version = '4.7.0'
+mp.commandv('script-message', 'uosc-version', uosc_version)
 
 assdraw = require('mp.assdraw')
 opt = require('mp.options')

--- a/scripts/uosc/main.lua
+++ b/scripts/uosc/main.lua
@@ -1,5 +1,6 @@
 --[[ uosc 4.7.0 - 2023-Apr-15 | https://github.com/tomasklaen/uosc ]]
 local uosc_version = '4.7.0'
+
 mp.commandv('script-message', 'uosc-version', uosc_version)
 
 assdraw = require('mp.assdraw')
@@ -1148,9 +1149,6 @@ end)
 mp.register_script_message('show-submenu', function(id) toggle_menu_with_items({submenu = id}) end)
 mp.register_script_message('show-submenu-blurred', function(id)
 	toggle_menu_with_items({submenu = id, mouse_nav = true})
-end)
-mp.register_script_message('get-version', function(script)
-	mp.commandv('script-message-to', script, 'uosc-version', config.version)
 end)
 mp.register_script_message('open-menu', function(json, submenu_id)
 	local data = utils.parse_json(json)


### PR DESCRIPTION
Scripts that offer a UI variant based on the uosc menu might get called right after startup before uosc manages to respond to their `get-version` request. As a result the non uosc UI will be shown. If we proactively broadcast the version as soon as possible then we minimize the chance of that happening.

That came up because of https://github.com/po5/memo/issues/16, where in a little test script I had to add a timeout of >= 1 to get the uosc menu, anything less would not reliably open the uosc menu.
With the early broadcast a timeout of 0.8 is enough, which is still not great, but the chance is also greatly increased with smaller values. I'll have to look if something can be done about that on the mpv side at some point, but it's better then nothing.