### PR TITLE
fix: runtime updates for progress option

### DIFF
--- a/scripts/uosc/elements/Timeline.lua
+++ b/scripts/uosc/elements/Timeline.lua
@@ -118,7 +118,10 @@ function Timeline:on_prop_fullormaxed()
 	self:update_dimensions()
 end
 function Timeline:on_display() self:update_dimensions() end
-function Timeline:on_options() self:update_dimensions() end
+function Timeline:on_options()
+	self:decide_progress_size()
+	self:update_dimensions()
+end
 function Timeline:handle_cursor_up()
 	if self.pressed then
 		mp.set_property_native('pause', self.pressed.pause)


### PR DESCRIPTION
Fixes #373

<hr/>

Now that elements can be created/destroyed at runtime, an alternative way of dealing with script-opts updates would be to destroy and recreate everything. If it works on startup, it'll also work during runtime.