### PR TITLE
fix: shifting of digits due to non monospace font

### DIFF
--- a/dist/scripts/uosc/elements/Timeline.lua
+++ b/dist/scripts/uosc/elements/Timeline.lua
@@ -351,6 +351,34 @@ function Timeline:render()
 		ass:txt(x, y, align, text, opts)
 	end
 
+	local function draw_semi_monospace_time(x, y, align, time_human, opts)
+		local widths, width_total = {}, 0
+		zero_rep = timestamp_zero_rep(time_human)
+		for i = 1, #zero_rep do
+			local width = text_width(zero_rep:sub(i, i), opts)
+			widths[i] = width
+			width_total = width_total + width
+		end
+		if align == 6 then
+			x = x - width_total
+		elseif align == 5 then
+			x = x - width_total / 2
+		end
+		local opacity = opts.opacity
+		opts.opacity = {main = opacity, primary = 0}
+		for i, width in ipairs(widths) do
+			draw_timeline_text(x + width / 2, y, 5, time_human:sub(i, i), opts)
+			x = x + width
+		end
+		x = x - width_total
+		opts.opacity.main, opts.opacity.primary = 0, opacity
+		for i, width in ipairs(widths) do
+			draw_timeline_text(x + width / 2, y, 5, time_human:sub(i, i), opts)
+			x = x + width
+		end
+		opts.opacity = opacity
+	end
+
 	-- Time values
 	if text_opacity > 0 then
 		local time_opts = {size = self.font_size, opacity = text_opacity, border = 2}
@@ -367,17 +395,17 @@ function Timeline:render()
 			local time_width_end = timestamp_width(state.destination_time_human, time_opts)
 			local min_x, max_x = bax + spacing + 5 + time_width, bbx - spacing - 5 - time_width_end
 			if x < min_x then x = min_x elseif x + width > max_x then x, align = max_x, 6 end
-			draw_timeline_text(x, fcy, align, human, cache_opts)
+			draw_semi_monospace_time(x, fcy, align, human, cache_opts)
 		end
 
 		-- Elapsed time
 		if state.time_human then
-			draw_timeline_text(bax + spacing, fcy, 4, state.time_human, time_opts)
+			draw_semi_monospace_time(bax + spacing, fcy, 4, state.time_human, time_opts)
 		end
 
 		-- End time
 		if state.destination_time_human then
-			draw_timeline_text(bbx - spacing, fcy, 6, state.destination_time_human, time_opts)
+			draw_semi_monospace_time(bbx - spacing, fcy, 6, state.destination_time_human, time_opts)
 		end
 	end
 

--- a/dist/scripts/uosc/elements/Timeline.lua
+++ b/dist/scripts/uosc/elements/Timeline.lua
@@ -342,48 +342,13 @@ function Timeline:render()
 		end
 	end
 
-	local function draw_timeline_text(x, y, align, text, opts)
+	local function draw_timeline_timestamp(x, y, align, timestamp, opts)
 		opts.color, opts.border_color = fgt, fg
 		opts.clip = '\\clip(' .. foreground_coordinates .. ')'
-		ass:txt(x, y, align, text, opts)
+		ass:timestamp(x, y, align, timestamp, opts)
 		opts.color, opts.border_color = bgt, bg
 		opts.clip = '\\iclip(' .. foreground_coordinates .. ')'
-		ass:txt(x, y, align, text, opts)
-	end
-
-	local function draw_semi_monospace_time(x, y, align, time_human, opts)
-		local widths, width_total = {}, 0
-		zero_rep = timestamp_zero_rep(time_human)
-		for i = 1, #zero_rep do
-			local width = text_width(zero_rep:sub(i, i), opts)
-			widths[i] = width
-			width_total = width_total + width
-		end
-		-- shift x and y to fit align 5
-		local mod_align = align % 3
-		if mod_align == 0 then
-			x = x - width_total
-		elseif mod_align == 2 then
-			x = x - width_total / 2
-		end
-		if align < 4 then
-			y = y - opts.size / 2
-		elseif align > 6 then
-			y = y + opts.size / 2
-		end
-		local opacity = opts.opacity
-		opts.opacity = {main = opacity or 1, primary = 0}
-		for i, width in ipairs(widths) do
-			draw_timeline_text(x + width / 2, y, 5, time_human:sub(i, i), opts)
-			x = x + width
-		end
-		x = x - width_total
-		opts.opacity.main, opts.opacity.primary = 0, opacity or 1
-		for i, width in ipairs(widths) do
-			draw_timeline_text(x + width / 2, y, 5, time_human:sub(i, i), opts)
-			x = x + width
-		end
-		opts.opacity = opacity
+		ass:timestamp(x, y, align, timestamp, opts)
 	end
 
 	-- Time values
@@ -402,17 +367,17 @@ function Timeline:render()
 			local time_width_end = timestamp_width(state.destination_time_human, time_opts)
 			local min_x, max_x = bax + spacing + 5 + time_width, bbx - spacing - 5 - time_width_end
 			if x < min_x then x = min_x elseif x + width > max_x then x, align = max_x, 6 end
-			draw_semi_monospace_time(x, fcy, align, human, cache_opts)
+			draw_timeline_timestamp(x, fcy, align, human, cache_opts)
 		end
 
 		-- Elapsed time
 		if state.time_human then
-			draw_semi_monospace_time(bax + spacing, fcy, 4, state.time_human, time_opts)
+			draw_timeline_timestamp(bax + spacing, fcy, 4, state.time_human, time_opts)
 		end
 
 		-- End time
 		if state.destination_time_human then
-			draw_semi_monospace_time(bbx - spacing, fcy, 6, state.destination_time_human, time_opts)
+			draw_timeline_timestamp(bbx - spacing, fcy, 6, state.destination_time_human, time_opts)
 		end
 	end
 
@@ -430,10 +395,10 @@ function Timeline:render()
 		local tooltip_anchor = {ax = ax, ay = ay - self.top_border, bx = bx, by = by}
 
 		-- Timestamp
-		local opts = {size = self.font_size, offset = timestamp_gap, margin = tooltip_gap}
+		local opts = {size = self.font_size, offset = timestamp_gap, margin = tooltip_gap, timestamp = true}
 		local hovered_time_human = format_time(hovered_seconds, state.duration)
 		opts.width_overwrite = timestamp_width(hovered_time_human, opts)
-		tooltip_anchor = ass:tooltip(tooltip_anchor, hovered_time_human, opts, draw_semi_monospace_time)
+		tooltip_anchor = ass:tooltip(tooltip_anchor, hovered_time_human, opts)
 
 		-- Thumbnail
 		if not thumbnail.disabled

--- a/dist/scripts/uosc/elements/Timeline.lua
+++ b/dist/scripts/uosc/elements/Timeline.lua
@@ -359,19 +359,26 @@ function Timeline:render()
 			widths[i] = width
 			width_total = width_total + width
 		end
-		if align == 6 then
+		-- shift x and y to fit align 5
+		local mod_align = align % 3
+		if mod_align == 0 then
 			x = x - width_total
-		elseif align == 5 then
+		elseif mod_align == 2 then
 			x = x - width_total / 2
 		end
+		if align < 4 then
+			y = y - opts.size / 2
+		elseif align > 6 then
+			y = y + opts.size / 2
+		end
 		local opacity = opts.opacity
-		opts.opacity = {main = opacity, primary = 0}
+		opts.opacity = {main = opacity or 1, primary = 0}
 		for i, width in ipairs(widths) do
 			draw_timeline_text(x + width / 2, y, 5, time_human:sub(i, i), opts)
 			x = x + width
 		end
 		x = x - width_total
-		opts.opacity.main, opts.opacity.primary = 0, opacity
+		opts.opacity.main, opts.opacity.primary = 0, opacity or 1
 		for i, width in ipairs(widths) do
 			draw_timeline_text(x + width / 2, y, 5, time_human:sub(i, i), opts)
 			x = x + width
@@ -426,7 +433,7 @@ function Timeline:render()
 		local opts = {size = self.font_size, offset = timestamp_gap, margin = tooltip_gap}
 		local hovered_time_human = format_time(hovered_seconds, state.duration)
 		opts.width_overwrite = timestamp_width(hovered_time_human, opts)
-		tooltip_anchor = ass:tooltip(tooltip_anchor, hovered_time_human, opts)
+		tooltip_anchor = ass:tooltip(tooltip_anchor, hovered_time_human, opts, draw_semi_monospace_time)
 
 		-- Thumbnail
 		if not thumbnail.disabled

--- a/dist/scripts/uosc/elements/Timeline.lua
+++ b/dist/scripts/uosc/elements/Timeline.lua
@@ -345,10 +345,11 @@ function Timeline:render()
 	local function draw_timeline_timestamp(x, y, align, timestamp, opts)
 		opts.color, opts.border_color = fgt, fg
 		opts.clip = '\\clip(' .. foreground_coordinates .. ')'
-		ass:timestamp(x, y, align, timestamp, opts)
+		local func = options.time_precision > 0 and ass.timestamp or ass.txt
+		func(ass, x, y, align, timestamp, opts)
 		opts.color, opts.border_color = bgt, bg
 		opts.clip = '\\iclip(' .. foreground_coordinates .. ')'
-		ass:timestamp(x, y, align, timestamp, opts)
+		func(ass, x, y, align, timestamp, opts)
 	end
 
 	-- Time values
@@ -395,7 +396,9 @@ function Timeline:render()
 		local tooltip_anchor = {ax = ax, ay = ay - self.top_border, bx = bx, by = by}
 
 		-- Timestamp
-		local opts = {size = self.font_size, offset = timestamp_gap, margin = tooltip_gap, timestamp = true}
+		local opts = {
+			size = self.font_size, offset = timestamp_gap, margin = tooltip_gap, timestamp = options.time_precision > 0
+		}
 		local hovered_time_human = format_time(hovered_seconds, state.duration)
 		opts.width_overwrite = timestamp_width(hovered_time_human, opts)
 		tooltip_anchor = ass:tooltip(tooltip_anchor, hovered_time_human, opts)

--- a/dist/scripts/uosc/lib/ass.lua
+++ b/dist/scripts/uosc/lib/ass.lua
@@ -85,9 +85,8 @@ end
 -- Tooltip.
 ---@param element Rect
 ---@param value string|number
----@param opts? {size?: number; offset?: number; bold?: boolean; italic?: boolean; width_overwrite?: number, margin?: number; responsive?: boolean; lines?: integer}
----@param txt_func? function
-function ass_mt:tooltip(element, value, opts, txt_func)
+---@param opts? {size?: number; offset?: number; bold?: boolean; italic?: boolean; width_overwrite?: number, margin?: number; responsive?: boolean; lines?: integer, timestamp?: boolean}
+function ass_mt:tooltip(element, value, opts)
 	if value == '' then return end
 	opts = opts or {}
 	opts.size = opts.size or round(16 * state.scale)
@@ -108,12 +107,59 @@ function ass_mt:tooltip(element, value, opts, txt_func)
 	local ay = (align_top and y - opts.size * opts.lines - 2 * padding_y or y)
 	local by = (align_top and y or y + opts.size * opts.lines + 2 * padding_y)
 	self:rect(ax, ay, bx, by, {color = bg, opacity = config.opacity.tooltip, radius = state.radius})
-	if txt_func then
-		txt_func(x, align_top and y - padding_y or y + padding_y, align_top and 2 or 8, value, opts)
-	else
-		self:txt(x, align_top and y - padding_y or y + padding_y, align_top and 2 or 8, value, opts)
-	end
+	local func = opts.timestamp and self.timestamp or self.txt
+	func(self, x, align_top and y - padding_y or y + padding_y, align_top and 2 or 8, tostring(value), opts)
 	return {ax = element.ax, ay = ay, bx = element.bx, by = by}
+end
+
+-- Timestamp with each digit positioned as if it was replaced with 0
+---@param x number
+---@param y number
+---@param align number
+---@param timestamp string
+---@param opts {size: number; opacity?: number|{primary?: number; border?: number, shadow?: number, main?: number}}
+function ass_mt:timestamp(x, y, align, timestamp, opts)
+	local widths, width_total = {}, 0
+	zero_rep = timestamp_zero_rep(timestamp)
+	for i = 1, #zero_rep do
+		local width = text_width(zero_rep:sub(i, i), opts)
+		widths[i] = width
+		width_total = width_total + width
+	end
+
+	-- shift x and y to fit align 5
+	local mod_align = align % 3
+	if mod_align == 0 then
+		x = x - width_total
+	elseif mod_align == 2 then
+		x = x - width_total / 2
+	end
+	if align < 4 then
+		y = y - opts.size / 2
+	elseif align > 6 then
+		y = y + opts.size / 2
+	end
+
+	local opacity = opts.opacity
+	local primary_opacity
+	if type(opacity) == 'table' then
+		opts.opacity = {main = opacity.main, border = opacity.border, shadow = opacity.shadow, primary = 0}
+		primary_opacity = opacity.primary or opacity.main
+	else
+		opts.opacity = {main = opacity, primary = 0}
+		primary_opacity = opacity
+	end
+	for i, width in ipairs(widths) do
+		self:txt(x + width / 2, y, 5, timestamp:sub(i, i), opts)
+		x = x + width
+	end
+	x = x - width_total
+	opts.opacity = {main = 0, primary = primary_opacity or 1}
+	for i, width in ipairs(widths) do
+		self:txt(x + width / 2, y, 5, timestamp:sub(i, i), opts)
+		x = x + width
+	end
+	opts.opacity = opacity
 end
 
 -- Rectangle.

--- a/dist/scripts/uosc/lib/ass.lua
+++ b/dist/scripts/uosc/lib/ass.lua
@@ -86,7 +86,8 @@ end
 ---@param element Rect
 ---@param value string|number
 ---@param opts? {size?: number; offset?: number; bold?: boolean; italic?: boolean; width_overwrite?: number, margin?: number; responsive?: boolean; lines?: integer}
-function ass_mt:tooltip(element, value, opts)
+---@param txt_func? function
+function ass_mt:tooltip(element, value, opts, txt_func)
 	if value == '' then return end
 	opts = opts or {}
 	opts.size = opts.size or round(16 * state.scale)
@@ -107,7 +108,11 @@ function ass_mt:tooltip(element, value, opts)
 	local ay = (align_top and y - opts.size * opts.lines - 2 * padding_y or y)
 	local by = (align_top and y or y + opts.size * opts.lines + 2 * padding_y)
 	self:rect(ax, ay, bx, by, {color = bg, opacity = config.opacity.tooltip, radius = state.radius})
-	self:txt(x, align_top and y - padding_y or y + padding_y, align_top and 2 or 8, value, opts)
+	if txt_func then
+		txt_func(x, align_top and y - padding_y or y + padding_y, align_top and 2 or 8, value, opts)
+	else
+		self:txt(x, align_top and y - padding_y or y + padding_y, align_top and 2 or 8, value, opts)
+	end
 	return {ax = element.ax, ay = ay, bx = element.bx, by = by}
 end
 

--- a/dist/scripts/uosc/lib/text.lua
+++ b/dist/scripts/uosc/lib/text.lua
@@ -397,17 +397,23 @@ do
 	---@type {[string]: string}
 	local cache = {}
 
-	---Get width of formatted timestamp as if all the digits were replaced with 0
+	---Replace all timestamp digits with 0
 	---@param timestamp string
-	---@param opts {size: number; bold?: boolean; italic?: boolean}
-	---@return number
-	function timestamp_width(timestamp, opts)
+	function timestamp_zero_rep(timestamp)
 		local substitute = cache[#timestamp]
 		if not substitute then
 			substitute = timestamp:gsub('%d', '0')
 			cache[#timestamp] = substitute
 		end
-		return text_width(substitute, opts)
+		return substitute
+	end
+
+	---Get width of formatted timestamp as if all the digits were replaced with 0
+	---@param timestamp string
+	---@param opts {size: number; bold?: boolean; italic?: boolean}
+	---@return number
+	function timestamp_width(timestamp, opts)
+		return text_width(timestamp_zero_rep(timestamp), opts)
 	end
 end
 


### PR DESCRIPTION
Why draw the whole string at once when you can draw each symbol individually two times!

Not sure about this but it does solve the shifting digits mentioned in the comment.

~~Would be nice to also use this in the time tooltip, but I don't see an easy way of doing that.~~

Ref. https://github.com/tomasklaen/uosc/issues/722#issuecomment-1783866244