### PR TITLE
feat!: reworked colors and opacity configuration

### DIFF
--- a/src/uosc.conf
+++ b/src/uosc.conf
@@ -148,16 +148,9 @@ font_scale=1
 text_border=1.2
 # Border radius of buttons, menus, and all other rectangles
 border_radius=4
-# A comma delimited list of color overrides in RGB HEX format.
-# Defaults: foreground=ffffff,foreground_text=000000,background=000000,background_text=ffffff,curtain=111111,
-#           success=a5e075,error=ff616e
-color=
-# A comma delimited list of opacity overrides for various UI element backgrounds and shapes.
-# This does not affect any text, which is always rendered fully opaque.
-# Defaults: timeline=0.9,position=1,chapters=0.8,slider=0.9,slider_gauge=1,speed=0.6,menu=1,submenu=0.4,
-#           border=1,title=1,tooltip=1,thumbnail=1,curtain=0.8,idle_indicator=0.8,audio_indicator=0.5,
-#           buffering_indicator=0.3
-opacity=
+# A comma delimited list of color overrides in RGB(A) HEX format (same as CSS). Defaults:
+# timeline=000000e6,timeline_border=000e,timeline_text=fff,timeline_text_border=000,timeline_cursor=fff3,timeline_position=fff,timeline_position_text=000,timeline_position_text_border=0000,timeline_position_cursor=0003,button=0000,button_icon=fff,button_icon_border=000,button_hover=fff1,button_active=fff,button_active_icon=000,button_badge=fff,button_badge_text=000,pause_indicator=fff,pause_indicator_fade=0004,volume=000000e6,volume_text=fff,volume_range=fff,volume_range_text=000,speed=0009,speed_text=fff,speed_text_border=000,speed_notch=fff,speed_notch_border=000,curtain=1111,menu=000,menu_text=fff,menu_placeholder=fff6,menu_item_hover=fff1,menu_item_active=fff,menu_item_active_text=000,title=000000e6,title_text=fff,title_text_border=000,playlist_position=fff,playlist_position_text=000,playlist_position_text_border=0000,success=a5e075,warning=ffc461,error=ff616e,ads=c54e4e80,openings=30abf964,endings=30abf964
+colors=
 # Use a faster estimation method instead of accurate measurement
 # setting this to `no` might have a noticeable impact on performance, especially in large menus.
 text_width_estimation=yes

--- a/src/uosc/lib/std.lua
+++ b/src/uosc/lib/std.lua
@@ -8,11 +8,25 @@ function round(number) return math.floor(number + 0.5) end
 ---@param max number
 function clamp(min, value, max) return math.max(min, math.min(value, max)) end
 
----@param rgba string `rrggbb` or `rrggbbaa` hex string.
-function serialize_rgba(rgba)
-	local a = rgba:sub(7, 8)
+---@alias Color {color: string; opacity: number}
+
+---@param hex string rgb, rgba, rrggbb, rrggbbaa hex string.
+---@return Color color If input color was invalid we return a pure red as fallback.
+function serialize_rgba(hex)
+	if not hex or type(hex) ~= 'string' or #hex < 3 or #hex == 5 or #hex == 7 or #hex > 8 or hex:match('[^0-9a-f]') then
+		hex = 'ff0000' -- fallback to pure red
+	end
+	if #hex == 3 or #hex == 4 then
+		local expanded = ''
+		for i = 1, #hex, 1 do
+			local char = hex:sub(i, i)
+			expanded = expanded .. char .. char
+		end
+		hex = expanded
+	end
+	local a = hex:sub(7, 8)
 	return {
-		color = rgba:sub(5, 6) .. rgba:sub(3, 4) .. rgba:sub(1, 2),
+		color = hex:sub(5, 6) .. hex:sub(3, 4) .. hex:sub(1, 2),
 		opacity = clamp(0, tonumber(#a == 2 and a or 'ff', 16) / 255, 1),
 	}
 end
@@ -59,7 +73,7 @@ function comma_split(input)
 	if not input then return {} end
 	if type(input) == 'table' then return itable_map(input, tostring) end
 	local str = tostring(input)
-	return str:match('^%s*$') and {} or split(str, ' *, *')
+	return str:match('^%s*$') and {} or split(str, ' *,+ *')
 end
 
 -- Get index of the last appearance of `sub` in `str`.

--- a/src/uosc/main.lua
+++ b/src/uosc/main.lua
@@ -131,35 +131,6 @@ local intl = require('lib/intl')
 t = intl.t
 
 --[[ CONFIG ]]
-local config_defaults = {
-	color = {
-		foreground = serialize_rgba('ffffff').color,
-		foreground_text = serialize_rgba('000000').color,
-		background = serialize_rgba('000000').color,
-		background_text = serialize_rgba('ffffff').color,
-		curtain = serialize_rgba('111111').color,
-		success = serialize_rgba('a5e075').color,
-		error = serialize_rgba('ff616e').color,
-	},
-	opacity = {
-		timeline = 0.9,
-		position = 1,
-		chapters = 0.8,
-		slider = 0.9,
-		slider_gauge = 1,
-		speed = 0.6,
-		menu = 1,
-		submenu = 0.4,
-		border = 1,
-		title = 1,
-		tooltip = 1,
-		thumbnail = 1,
-		curtain = 0.8,
-		idle_indicator = 0.8,
-		audio_indicator = 0.5,
-		buffering_indicator = 0.3,
-	},
-}
 config = {
 	version = uosc_version,
 	open_subtitles_api_key = 'b0rd16N0bp7DETMpO4pYZwIqmQkZbYQr',
@@ -204,8 +175,8 @@ config = {
 		---@type table<string, {color: string; opacity: number; patterns?: string[]}>
 		local ranges = {}
 		if options.chapter_ranges and options.chapter_ranges ~= '' then
-			for _, definition in ipairs(split(options.chapter_ranges, ' *,+ *')) do
-				local name_color = split(definition, ' *:+ *')
+			for _, definition in ipairs(comma_split(options.chapter_ranges)) do
+				local name_color = comma_split(definition, ':')
 				local name, color = name_color[1], name_color[2]
 				if name and color
 					and name:match('^[a-zA-Z0-9_]+$') and color:match('^[a-fA-F0-9]+$')
@@ -222,6 +193,58 @@ config = {
 	opacity = table_copy(config_defaults.opacity),
 	cursor_leave_fadeout_elements = {'timeline', 'volume', 'top_bar', 'controls'},
 }
+---@class Colors
+local color_defaults = {
+	timeline = serialize_rgba('000000e6'),
+	timeline_border = serialize_rgba('000e'),
+	timeline_text = serialize_rgba('fff'),
+	timeline_text_border = serialize_rgba('000'),
+	timeline_cursor = serialize_rgba('fff3'),
+	timeline_position = serialize_rgba('fff'),
+	timeline_position_text = serialize_rgba('000'),
+	timeline_position_text_border = serialize_rgba('0000'),
+	timeline_position_cursor = serialize_rgba('0003'),
+	button = serialize_rgba('0000'),
+	button_icon = serialize_rgba('fff'),
+	button_icon_border = serialize_rgba('000'),
+	button_hover = serialize_rgba('fff1'),
+	button_active = serialize_rgba('fff'),
+	button_active_icon = serialize_rgba('000'),
+	button_badge = serialize_rgba('fff'),
+	button_badge_text = serialize_rgba('000'),
+	pause_indicator = serialize_rgba('fff'),
+	pause_indicator_fade = serialize_rgba('0004'),
+	volume = serialize_rgba('000000e6'),
+	volume_text = serialize_rgba('fff'),
+	volume_range = serialize_rgba('fff'),
+	volume_range_text = serialize_rgba('000'),
+	speed = serialize_rgba('0009'),
+	speed_text = serialize_rgba('fff'),
+	speed_text_border = serialize_rgba('000'),
+	speed_notch = serialize_rgba('fff'),
+	speed_notch_border = serialize_rgba('000'),
+	curtain = serialize_rgba('1111'),
+	menu = serialize_rgba('000'),
+	menu_text = serialize_rgba('fff'),
+	menu_placeholder = serialize_rgba('fff6'),
+	menu_item_hover = serialize_rgba('fff1'),
+	menu_item_active = serialize_rgba('fff'),
+	menu_item_active_text = serialize_rgba('000'),
+	title = serialize_rgba('000000e6'),
+	title_text = serialize_rgba('fff'),
+	title_text_border = serialize_rgba('000'),
+	playlist_position = serialize_rgba('fff'),
+	playlist_position_text = serialize_rgba('000'),
+	playlist_position_text_border = serialize_rgba('0000'),
+	success = serialize_rgba('a5e075'),
+	warning = serialize_rgba('ffc461'),
+	error = serialize_rgba('ff616e'),
+	ads = serialize_rgba('c54e4e80'),
+	openings = serialize_rgba('30abf964'),
+	endings = serialize_rgba('30abf964'),
+}
+---@type Colors
+color = {}
 
 -- Updates config with values dependent on options
 function update_config()
@@ -235,17 +258,8 @@ function update_config()
 		config[option_name] = flags
 	end
 
-	-- Opacity
-	config.opacity = table_assign({}, config_defaults.opacity, serialize_key_value_list(options.opacity,
-		function(value, key)
-			return clamp(0, tonumber(value) or config.opacity[key], 1)
-		end
-	))
-
-	-- Color
-	config.color = table_assign({}, config_defaults.color, serialize_key_value_list(options.color, function(value)
-		return serialize_rgba(value).color
-	end))
+	-- Colors
+	color = table_assign({}, color_defaults, serialize_key_value_list(options.colors, serialize_rgba))
 
 	-- Global color shorthands
 	fg, bg = config.color.foreground, config.color.background


### PR DESCRIPTION
Don't test this as it doesn't work yet, it's just a proof of concept of what I've been thinking of doing:

---

Options `color` and `opacity` have been removed, and replaced with a single option `colors` which now accepts RGB(A) values for pretty much all colors throughout uosc. Example:

```
colors=timeline=000000e6,timeline_border=000e,timeline_text=fff,timeline_text_border=000,...
```

This simplifies the config (one less option, and opacities are now right next to colors they control) as well as provides more customization than before.

Since this is now just a single option, we could even have a _Themes_ wiki page for people to share their `colors=` along with screenshots.

The only problem is that there's now a lot of these values, and some are quite verbose, so any ideas on how to simplify them?

```lua
local color_defaults = {
	timeline = '000000e6',
	timeline_border = '000e',
	timeline_text = 'fff',
	timeline_text_border = '000',
	timeline_cursor = 'fff3',
	timeline_position = 'fff',
	timeline_position_text = '000',
	timeline_position_text_border = '0000',
	timeline_position_cursor = '0003',
	button = '0000',
	button_icon = 'fff',
	button_icon_border = '000',
	button_hover = 'fff1',
	button_active = 'fff',
	button_active_icon = '000',
	button_badge = 'fff',
	button_badge_text = '000',
	pause_indicator = 'fff',
	pause_indicator_fade = '0004',
	volume = '000000e6',
	volume_text = 'fff',
	volume_range = 'fff',
	volume_range_text = '000',
	speed = '0009',
	speed_text = 'fff',
	speed_text_border = '000',
	speed_notch = 'fff',
	speed_notch_border = '000',
	curtain = '1111',
	menu = '000',
	menu_text = 'fff',
	menu_placeholder = 'fff6',
	menu_item_hover = 'fff1',
	menu_item_active = 'fff',
	menu_item_active_text = '000',
	title = '000000e6',
	title_text = 'fff',
	title_text_border = '000',
	playlist_position = 'fff',
	playlist_position_text = '000',
	playlist_position_text_border = '0000',
	success = 'a5e075',
	warning = 'ffc461',
	error = 'ff616e',
	ads = 'c54e4e80',
	openings = '30abf964',
	endings = '30abf964',
}
```