### PR TITLE
tweak: update scroll position when moving items like when navigating

### DIFF
--- a/src/uosc/elements/Menu.lua
+++ b/src/uosc/elements/Menu.lua
@@ -595,7 +595,7 @@ function Menu:move_selected_item_to(index)
 	if callback and from and from ~= index and index >= 1 and index <= #self.current.items then
 		callback(from, index, self.current.submenu_path)
 		self.current.selected_index = index
-		self:set_scroll_by((index - from) * self.scroll_step)
+		self:scroll_to_index(index, self.current, true)
 	end
 end
 


### PR DESCRIPTION
This keeps the selected item in the middle of the scroll position, just like when navigating.

Otherwise the scrolling behavior is inconsistent between moving and navigating, and leads to odd situations like when moving the first playlist item down it's impossible to see what's above it, which is annoying when overshooting and having to go back up a bit.

Also weirdly the selected item position in the scroll view changed when holding down the up or down button. The item moved faster then the scroll position. No idea why that happened, but with this change that's not a problem anymore.