### PR TITLE
fix: correctly update proximities on mouse enter and record position

### DIFF
--- a/src/uosc/lib/cursor.lua
+++ b/src/uosc/lib/cursor.lua
@@ -228,8 +228,6 @@ function cursor:move(x, y)
 			Elements:update_proximities()
 			Elements:trigger('global_mouse_leave')
 		else
-			Elements:update_proximities()
-
 			if self.hidden then
 				-- Cancel potential fadeouts
 				for _, id in ipairs(config.cursor_leave_fadeout_elements) do
@@ -237,12 +235,12 @@ function cursor:move(x, y)
 				end
 
 				self.hidden = false
-				self.history:clear()
 				Elements:trigger('global_mouse_enter')
-			else
-				-- Update history
-				self.history:insert({x = self.x, y = self.y, time = mp.get_time()})
 			end
+
+			Elements:update_proximities()
+			-- Update history
+			self.history:insert({x = self.x, y = self.y, time = mp.get_time()})
 		end
 
 		Elements:proximity_trigger('mouse_move')


### PR DESCRIPTION
`Element:update_proximity()` checks for `cursor.hidden`, which is why we have to update that before updating the proximities.

Also it doesn't make sense to not record the first cursor position on enter.