### PR TITLE
fix: don't cause a fling in update_dimensions()

### DIFF
--- a/src/uosc/elements/Menu.lua
+++ b/src/uosc/elements/Menu.lua
@@ -338,8 +338,7 @@ function Menu:update_dimensions()
 			menu.search.max_width = math.max(menu.search.max_width, menu.width)
 		end
 		menu.scroll_height = math.max(content_height - menu.height - self.item_spacing, 0)
-		menu.scroll_y = menu.scroll_y or 0
-		self:scroll_to(menu.scroll_y, menu) -- clamps scroll_y to scroll limits
+		self:set_scroll_to(menu.scroll_y, menu) -- clamps scroll_y to scroll limits
 	end
 
 	self:update_coordinates()


### PR DESCRIPTION
Opening a large menu with a selected item would not scroll all the way to that selected item if there was a menu update during the initial fling.

That's noticeable when opening the menu from my subtitle-lines script while the video is playing. When the active subtitles change right after opening the menu, the initial fling gets interrupted and it gets stuck somewhere in the middle.