### PR TITLE
tweak: always scroll to selected index on menu open

### DIFF
--- a/src/uosc/elements/Menu.lua
+++ b/src/uosc/elements/Menu.lua
@@ -125,11 +125,8 @@ function Menu:init(data, callback, opts)
 	mp.set_property_native('user-data/uosc/menu/type', self.type or 'undefined')
 	self:update(data)
 
-	if self.mouse_nav then
-		if self.current then self.current.selected_index = nil end
-	else
-		for _, menu in ipairs(self.all) do self:scroll_to_index(menu.selected_index, menu) end
-	end
+	for _, menu in ipairs(self.all) do self:scroll_to_index(menu.selected_index, menu) end
+	if self.mouse_nav then self.current.selected_index = nil end
 
 	self:tween_property('opacity', 0, 1)
 	self:enable_key_bindings()


### PR DESCRIPTION
I don't think there is currently a use case for this, but maybe there will be at some point and it doesn't hurt.

This would enable scrolling to some item on menu open even with `mouse_nav` set, but currently any place that can open a menu with `selected_index` set doesn't have `mouse_nav` set.