### PR TITLE
Fix interpreter crash

### DIFF
--- a/src/uosc/lib/intl.lua
+++ b/src/uosc/lib/intl.lua
@@ -26,18 +26,19 @@ function get_locale_from_json(path)
 
 	local meta, meta_error = utils.file_info(expand_path)
 	if not meta or not meta.is_file then
-		return {}
+		return nil
 	end
 
 	local json_file = io.open(expand_path, 'r')
 	if not json_file then
-		return {}
+		return nil
 	end
 
 	local json = json_file:read('*all')
 	json_file:close()
 
-	return utils.parse_json(json)
+	local json_table = utils.parse_json(json)
+	return json_table
 end
 
 ---@param text string

--- a/src/uosc/lib/std.lua
+++ b/src/uosc/lib/std.lua
@@ -202,7 +202,7 @@ end
 function table_assign(target, ...)
 	local args = {...}
 	for i = 1, select('#', ...) do
-		if args[i] then for key, value in pairs(args[i]) do target[key] = value end end
+		if type(args[i]) == 'table' then for key, value in pairs(args[i]) do target[key] = value end end
 	end
 	return target
 end

--- a/src/uosc/lib/std.lua
+++ b/src/uosc/lib/std.lua
@@ -160,7 +160,7 @@ end
 ---@return T[]
 function itable_join(...)
 	local args, result = {...}, {}
-	for i = 1, #args do
+	for i = 1, select('#', ...) do
 		if args[i] then for _, value in ipairs(args[i]) do result[#result + 1] = value end end
 	end
 	return result
@@ -201,7 +201,7 @@ end
 ---@return T
 function table_assign(target, ...)
 	local args = {...}
-	for i = 1, #args do
+	for i = 1, select('#', ...) do
 		if args[i] then for key, value in pairs(args[i]) do target[key] = value end end
 	end
 	return target


### PR DESCRIPTION
The crash happens because `utils.parse_json(json_string)` returns `table, nil, ''`, which then get passed as varargs to `table_assign()`, which doesn't like that string as argument.

I don't know if we should fix the crash by checking that the type is a table, because technically anything other then a table is a violation of defined argument types of the function and therefore it might be preferable the fix the call site (intl.lua:59 and intl.lua:63) instead?

Fixes crash from #792