### PR TITLE
fix: `show-in-directory` issue opening paths containing a comma (win)

### DIFF
--- a/src/uosc/main.lua
+++ b/src/uosc/main.lua
@@ -926,7 +926,7 @@ bind_command('show-in-directory', function()
 	if not state.path or is_protocol(state.path) then return end
 
 	if state.platform == 'windows' then
-		utils.subprocess_detached({args = {'explorer', '/select,', state.path}, cancellable = false})
+		utils.subprocess_detached({args = {'explorer', '/select,', state.path .. ' '}, cancellable = false})
 	elseif state.platform == 'darwin' then
 		utils.subprocess_detached({args = {'open', '-R', state.path}, cancellable = false})
 	elseif state.platform == 'linux' then


### PR DESCRIPTION
On Windows trying to open a path that contains a comma fails unless there's a space anywhere in the path, adding a trailing space to the end of it doesn't seem to bother `explorer /select,` and forces proper quotations.

Here's a bit more detail about this https://github.com/mpvnet-player/mpv.net/issues/580#issuecomment-1819365741