### PR TITLE
fix: buffering indicator id

### DIFF
--- a/src/uosc/elements/BufferingIndicator.lua
+++ b/src/uosc/elements/BufferingIndicator.lua
@@ -5,7 +5,7 @@ local BufferingIndicator = class(Element)
 
 function BufferingIndicator:new() return Class.new(self) --[[@as BufferingIndicator]] end
 function BufferingIndicator:init()
-	Element.init(self, 'buffer_indicator', {ignores_curtain = true, render_order = 2})
+	Element.init(self, 'buffering_indicator', {ignores_curtain = true, render_order = 2})
 	self.enabled = false
 	self:decide_enabled()
 end


### PR DESCRIPTION
The element id didn't match the id in the constructors table or the description in the config. Consequently it was possible to disable the indicator at startup, but once it was instantiated it wasn't possible to remove it again.

Fixes #808