### PR TITLE
main.lua: Support overriding `ziggy_path` via environment variable

### DIFF
--- a/src/uosc/main.lua
+++ b/src/uosc/main.lua
@@ -396,7 +396,7 @@ require('lib/menus')
 -- Determine path to ziggy
 do
 	local bin = 'ziggy-' .. (state.platform == 'windows' and 'windows.exe' or state.platform)
-	config.ziggy_path = join_path(mp.get_script_directory(), join_path('bin', bin))
+	config.ziggy_path = os.getenv('MPV_UOSC_ZIGGY') or join_path(mp.get_script_directory(), join_path('bin', bin))
 end
 
 --[[ STATE UPDATERS ]]


### PR DESCRIPTION
This is useful when running on a platform builds of `ziggy` aren't provided for... or when using a distro-provided build.

The idea for this patch originated in NixOS/nixpkgs#270962, as I needed a way to point `uosc` at the nix-managed build of `ziggy`.
