### PR TITLE
fix: click threshold not working when any clickable element visible

### DIFF
--- a/src/uosc/elements/Button.lua
+++ b/src/uosc/elements/Button.lua
@@ -23,7 +23,7 @@ function Button:init(id, props)
 end
 
 function Button:on_coordinates() self.font_size = round((self.by - self.ay) * 0.7) end
-function Button:handle_cursor_down()
+function Button:handle_cursor_click()
 	-- We delay the callback to next tick, otherwise we are risking race
 	-- conditions as we are in the middle of event dispatching.
 	-- For example, handler might add a menu to the end of the element stack, and that
@@ -34,7 +34,7 @@ end
 function Button:render()
 	local visibility = self:get_visibility()
 	if visibility <= 0 then return end
-	cursor:zone('primary_down', self, function() self:handle_cursor_down() end)
+	cursor:zone('primary_click', self, function() self:handle_cursor_click() end)
 
 	local ass = assdraw.ass_new()
 	local is_hover = self.proximity_raw == 0

--- a/src/uosc/elements/Menu.lua
+++ b/src/uosc/elements/Menu.lua
@@ -118,8 +118,6 @@ function Menu:init(data, callback, opts)
 	self.is_closing, self.is_closed = false, false
 	self.drag_last_y = nil
 	self.is_dragging = false
-	-- A flag for cursor zone to prevent window dragging on top of this element, since we're just passing `self` to it.
-	self.window_drag = false
 
 	if utils.shared_script_property_set then
 		utils.shared_script_property_set('uosc-menu-type', self.type or 'undefined')

--- a/src/uosc/elements/Menu.lua
+++ b/src/uosc/elements/Menu.lua
@@ -118,6 +118,8 @@ function Menu:init(data, callback, opts)
 	self.is_closing, self.is_closed = false, false
 	self.drag_last_y = nil
 	self.is_dragging = false
+	-- A flag for cursor zone to prevent window dragging on top of this element, since we're just passing `self` to it.
+	self.window_drag = false
 
 	if utils.shared_script_property_set then
 		utils.shared_script_property_set('uosc-menu-type', self.type or 'undefined')

--- a/src/uosc/elements/Speed.lua
+++ b/src/uosc/elements/Speed.lua
@@ -20,6 +20,8 @@ function Speed:init(props)
 	self.font_size = nil
 	---@type Dragging|nil
 	self.dragging = nil
+	-- A flag for cursor zone to prevent window dragging on top of this element, since we're just passing `self` to it.
+	self.window_drag = false
 end
 
 function Speed:on_coordinates()

--- a/src/uosc/elements/Speed.lua
+++ b/src/uosc/elements/Speed.lua
@@ -20,8 +20,6 @@ function Speed:init(props)
 	self.font_size = nil
 	---@type Dragging|nil
 	self.dragging = nil
-	-- A flag for cursor zone to prevent window dragging on top of this element, since we're just passing `self` to it.
-	self.window_drag = false
 end
 
 function Speed:on_coordinates()

--- a/src/uosc/elements/Speed.lua
+++ b/src/uosc/elements/Speed.lua
@@ -111,7 +111,7 @@ function Speed:render()
 		self:handle_cursor_down()
 		cursor:once('primary_up', function() self:handle_cursor_up() end)
 	end)
-	cursor:zone('secondary_down', self, function() mp.set_property_native('speed', 1) end)
+	cursor:zone('secondary_click', self, function() mp.set_property_native('speed', 1) end)
 	cursor:zone('wheel_down', self, function() self:handle_wheel_down() end)
 	cursor:zone('wheel_up', self, function() self:handle_wheel_up() end)
 

--- a/src/uosc/elements/TopBar.lua
+++ b/src/uosc/elements/TopBar.lua
@@ -16,7 +16,7 @@ function TopBarButton:init(id, props)
 	self.command = props.command
 end
 
-function TopBarButton:handle_cursor_down()
+function TopBarButton:handle_click()
 	mp.command(type(self.command) == 'function' and self.command() or self.command)
 end
 
@@ -29,7 +29,7 @@ function TopBarButton:render()
 	if self.proximity_raw == 0 then
 		ass:rect(self.ax, self.ay, self.bx, self.by, {color = self.background, opacity = visibility})
 	end
-	cursor:zone('primary_down', self, function() self:handle_cursor_down() end)
+	cursor:zone('primary_click', self, function() self:handle_click() end)
 
 	local width, height = self.bx - self.ax, self.by - self.ay
 	local icon_size = math.min(width, height) * 0.5
@@ -228,7 +228,7 @@ function TopBar:render()
 			title_ax = rect.bx + bg_margin
 
 			-- Click action
-			cursor:zone('primary_down', rect, function() mp.command('script-binding uosc/playlist') end)
+			cursor:zone('primary_click', rect, function() mp.command('script-binding uosc/playlist') end)
 		end
 
 		-- Skip rendering titles if there's not enough horizontal space
@@ -250,7 +250,7 @@ function TopBar:render()
 				local title_rect = {ax = title_ax, ay = title_ay, bx = bx, by = by}
 
 				if options.top_bar_alt_title_place == 'toggle' then
-					cursor:zone('primary_down', title_rect, function() self:toggle_title() end)
+					cursor:zone('primary_click', title_rect, function() self:toggle_title() end)
 				end
 
 				ass:rect(title_rect.ax, title_rect.ay, title_rect.bx, title_rect.by, {
@@ -310,7 +310,7 @@ function TopBar:render()
 				title_ay = rect.by + 1
 
 				-- Click action
-				cursor:zone('primary_down', rect, function() mp.command('script-binding uosc/chapters') end)
+				cursor:zone('primary_click', rect, function() mp.command('script-binding uosc/chapters') end)
 			end
 		end
 		self.title_by = title_ay - 1

--- a/src/uosc/elements/Updater.lua
+++ b/src/uosc/elements/Updater.lua
@@ -161,7 +161,7 @@ function Updater:render()
 		local y = round(button_rect.ay + (button_rect.by - button_rect.ay) / 2)
 		ass:icon(x, y, icon_size * 0.8, 'close', {color = bg})
 
-		cursor:zone('primary_down', button_rect, function() self:destroy() end)
+		cursor:zone('primary_click', button_rect, function() self:destroy() end)
 	end
 
 	return ass

--- a/src/uosc/elements/Volume.lua
+++ b/src/uosc/elements/Volume.lua
@@ -14,8 +14,6 @@ function VolumeSlider:init(props)
 	self.draw_nudge = false
 	self.spacing = 0
 	self.border_size = 0
-	-- A flag for cursor zone to prevent window dragging on top of this element, since we're just passing `self` to it.
-	self.window_drag = false
 	self:update_dimensions()
 end
 

--- a/src/uosc/elements/Volume.lua
+++ b/src/uosc/elements/Volume.lua
@@ -14,6 +14,8 @@ function VolumeSlider:init(props)
 	self.draw_nudge = false
 	self.spacing = 0
 	self.border_size = 0
+	-- A flag for cursor zone to prevent window dragging on top of this element, since we're just passing `self` to it.
+	self.window_drag = false
 	self:update_dimensions()
 end
 

--- a/src/uosc/elements/Volume.lua
+++ b/src/uosc/elements/Volume.lua
@@ -251,14 +251,14 @@ function Volume:render()
 	if visibility <= 0 then return end
 
 	-- Reset volume on secondary click
-	cursor:zone('secondary_down', self, function()
+	cursor:zone('secondary_click', self, function()
 		mp.set_property_native('mute', false)
 		mp.set_property_native('volume', 100)
 	end)
 
 	-- Mute button
 	local mute_rect = {ax = self.ax, ay = self.mute_ay, bx = self.bx, by = self.by}
-	cursor:zone('primary_down', mute_rect, function() mp.commandv('cycle', 'mute') end)
+	cursor:zone('primary_click', mute_rect, function() mp.commandv('cycle', 'mute') end)
 	local ass = assdraw.ass_new()
 	local width_half = (mute_rect.bx - mute_rect.ax) / 2
 	local height_half = (mute_rect.by - mute_rect.ay) / 2

--- a/src/uosc/lib/cursor.lua
+++ b/src/uosc/lib/cursor.lua
@@ -81,7 +81,7 @@ end
 -- Returns zone for event at current cursor position.
 ---@param event string
 function cursor:find_zone(event)
-	-- We ignore `move` because it's the most performance impacting event, and not needed as a zone at current time.
+	-- Premature optimization to ignore a high frequency event that is not needed as a zone atm.
 	if event == 'move' then return end
 
 	for i = #self.zones, 1, -1 do
@@ -95,13 +95,14 @@ end
 
 -- Defines an event zone for a hitbox on currently rendered screen. Available events:
 -- - primary_down, primary_up, primary_click, secondary_down, secondary_up, secondary_click, wheel_down, wheel_up
+--
 -- Notes:
 -- - Zones are cleared on beginning of every `render()`, and need to be rebound.
--- - One event type per zone: only the last bound zone per event type gets triggered.
--- - In current implementation, you can only use `_click` or `_down`. If you bind both, only the last bound one will fire.
--- - `primary_up` and `primary_click` prevent autohide when bound.
--- - Primary `_down` and `_click` automatically disable dragging. Define `window_drag = true` on hitbox to re-enable.
--- - `move` even zones are not triggered due to it being a high frequency event that is currently not needed as a zone.
+-- - One event type per zone: only the last bound zone per event gets triggered.
+-- - In current implementation, you have to choose between `_click` or `_down`. Binding both makes only the last bound fire.
+-- - Primary `_down` and `_click` disable dragging. Define `window_drag = true` on hitbox to re-enable.
+-- - Anything that disables dragging also implicitly disables cursor autohide.
+-- - `move` event zones are ignored due to it being a high frequency event that is currently not needed as a zone.
 ---@param event string
 ---@param hitbox Hitbox
 ---@param callback fun(...)

--- a/src/uosc/lib/utils.lua
+++ b/src/uosc/lib/utils.lua
@@ -1,7 +1,9 @@
 --[[ UI specific utilities that might or might not depend on its state or options ]]
 
 ---@alias Point {x: number; y: number}
----@alias Rect {ax: number, ay: number, bx: number, by: number}
+---@alias Rect {ax: number, ay: number, bx: number, by: number, window_drag?: boolean}
+---@alias Circle {point: Point, r: number, window_drag?: boolean}
+---@alias Hitbox Rect|Circle
 
 --- In place sorting of filenames
 ---@param filenames string[]
@@ -830,6 +832,9 @@ function render()
 	state.render_last_time = mp.get_time()
 
 	cursor:clear_zones()
+
+	-- Click on empty area detection
+	if setup_click_detection then setup_click_detection() end
 
 	-- Actual rendering
 	local ass = assdraw.ass_new()

--- a/src/uosc/lib/utils.lua
+++ b/src/uosc/lib/utils.lua
@@ -147,6 +147,13 @@ function get_point_to_point_proximity(point_a, point_b)
 	return math.sqrt(dx * dx + dy * dy)
 end
 
+---@param point Point
+---@param hitbox Hitbox
+function point_collides_with(point, hitbox)
+	return (hitbox.r and get_point_to_point_proximity(point, hitbox.point) <= hitbox.r) or
+		(not hitbox.r and get_point_to_rectangle_proximity(point, hitbox --[[@as Rect]]) == 0)
+end
+
 ---@param lax number
 ---@param lay number
 ---@param lbx number

--- a/src/uosc/main.lua
+++ b/src/uosc/main.lua
@@ -593,7 +593,7 @@ if options.click_threshold > 0 then
 	end
 	-- If this function exists, it'll be called at the beginning of render().
 	function setup_click_detection()
-		local hitbox = {ax = 0, ay = 0, bx = display.width, by = display.height}
+		local hitbox = {ax = 0, ay = 0, bx = display.width, by = display.height, window_drag = true}
 		cursor:zone('primary_down', hitbox, handle_down)
 		cursor:zone('primary_up', hitbox, handle_up)
 	end

--- a/src/uosc/main.lua
+++ b/src/uosc/main.lua
@@ -586,14 +586,17 @@ if options.click_threshold > 0 then
 		if delta > 0 and delta < click_time and delta > 0.02 then mp.command(options.click_command) end
 	end)
 	click_timer:kill()
-	mp.set_key_bindings({{'mbtn_left',
-		function() last_up = mp.get_time() end,
-		function()
-			last_down = mp.get_time()
-			if click_timer:is_enabled() then click_timer:kill() else click_timer:resume() end
-		end,
-	}}, 'mouse_movement', 'force')
-	mp.enable_key_bindings('mouse_movement', 'allow-vo-dragging+allow-hide-cursor')
+	local function handle_up() last_up = mp.get_time() end
+	local function handle_down()
+		last_down = mp.get_time()
+		if click_timer:is_enabled() then click_timer:kill() else click_timer:resume() end
+	end
+	-- If this function exists, it'll be called at the beginning of render().
+	function setup_click_detection()
+		local hitbox = {ax = 0, ay = 0, bx = display.width, by = display.height}
+		cursor:zone('primary_down', hitbox, handle_down)
+		cursor:zone('primary_up', hitbox, handle_up)
+	end
 end
 
 mp.observe_property('osc', 'bool', function(name, value) if value == true then mp.set_property('osc', 'no') end end)


### PR DESCRIPTION
This moves click threshold handling to cursor zones, and reworks them a bit. Each zone can now set `window_dragging = false` in their hitbox (defaults to `true` when `nil`), which will disable window dragging only when cursor is on top of that zone.

Resolves #820

---

There's a weird issue with this. If I click the close window button with this PR, the window closes, but the process doesn't actually exit. I have to Ctrl+C it in the console 😶. This doesn't happen on main. Anyone any ideas? It's not click threshold timer, as it happens even with it disabled.