### PR TITLE
fix: timestamp zero representation caching

### DIFF
--- a/src/uosc/lib/text.lua
+++ b/src/uosc/lib/text.lua
@@ -408,6 +408,10 @@ do
 	---@type {[string]: string}
 	local cache = {}
 
+	function timestamp_zero_rep_clear_cache()
+		cache = {}
+	end
+
 	---Replace all timestamp digits with 0
 	---@param timestamp string
 	function timestamp_zero_rep(timestamp)

--- a/src/uosc/main.lua
+++ b/src/uosc/main.lua
@@ -102,7 +102,10 @@ defaults = {
 	disable_elements = '',
 }
 options = table_copy(defaults)
-opt.read_options(options, 'uosc', function(_)
+opt.read_options(options, 'uosc', function(changed_options)
+	if changed_options.time_precision then
+		timestamp_zero_rep_clear_cache()
+	end
 	update_config()
 	update_human_times()
 	Manager:disable('user', options.disable_elements)


### PR DESCRIPTION
Caching the zero represenation sounds like a good idea, until the precision gets changed and then e.g. 01:40:23.13 returns -00:00:00.0 because it has the same amount of characters, messing up our width estimation and pseudo monospace thingy.

Clearing the cache on options change avoids such conflicts.

Fixes https://github.com/tomasklaen/uosc/issues/834#issuecomment-1896443240