### PR TITLE
fix: don't scroll to top on menu update during search

### DIFF
--- a/src/uosc/elements/Menu.lua
+++ b/src/uosc/elements/Menu.lua
@@ -757,8 +757,10 @@ function Menu:search_internal(menu, no_select_first)
 		end
 		menu.items = search_items(menu.search.source.items, query, search_submenus)
 		-- Select 1st item in search results
-		menu.scroll_y = 0
-		if not no_select_first then self:select_index(1, menu) end
+		if not no_select_first then
+			menu.scroll_y = 0
+			self:select_index(1, menu)
+		end
 	end
 	self:update_content_dimensions()
 end


### PR DESCRIPTION
This should have been part of #759, but never encountered it during testing.

When the selected index is kept, then the scroll position should also stay the same. Otherwise it's annoying when there are enough search results that scrolling is required.