### PR TITLE
fix: don't trim too much when speed < 1 with playtime-remaining

### DIFF
--- a/src/uosc/main.lua
+++ b/src/uosc/main.lua
@@ -435,7 +435,8 @@ function update_human_times()
 		if state.duration then
 			local speed = state.speed or 1
 			if options.destination_time == 'playtime-remaining' then
-				state.destination_time_human = format_time((state.time - state.duration) / speed, state.duration)
+				local max_seconds = speed >= 1 and state.duration or state.duration / speed
+				state.destination_time_human = format_time((state.time - state.duration) / speed, max_seconds)
 			elseif options.destination_time == 'total' then
 				state.destination_time_human = format_time(state.duration, state.duration)
 			else

--- a/src/uosc/main.lua
+++ b/src/uosc/main.lua
@@ -431,20 +431,21 @@ end
 
 function update_human_times()
 	if state.time then
-		state.time_human = format_time(state.time, state.duration)
+		local max_seconds = state.duration
 		if state.duration then
 			local speed = state.speed or 1
 			if options.destination_time == 'playtime-remaining' then
-				local max_seconds = speed >= 1 and state.duration or state.duration / speed
+				max_seconds = speed >= 1 and state.duration or state.duration / speed
 				state.destination_time_human = format_time((state.time - state.duration) / speed, max_seconds)
 			elseif options.destination_time == 'total' then
-				state.destination_time_human = format_time(state.duration, state.duration)
+				state.destination_time_human = format_time(state.duration, max_seconds)
 			else
-				state.destination_time_human = format_time(state.time - state.duration, state.duration)
+				state.destination_time_human = format_time(state.time - state.duration, max_seconds)
 			end
 		else
 			state.destination_time_human = nil
 		end
+		state.time_human = format_time(state.time, max_seconds)
 	else
 		state.time_human = nil
 	end


### PR DESCRIPTION
Speed < 1 can require more parts of the formatted time then when speed >= 1.
E.g. when a video is almost 1min long and the speed is reduced to <1 then the minutes part of the remaining time would still get trimmed, even though it's not `00:`.

Alternatively the max seconds could also be
```lua
local max_seconds = math.max(state.duration, (state.duration - state.time) / speed)
```
so that the time only gets longer when the remaining time is large enough to require less trimming.

Really not sure what the best way of handling this is...