### PR TITLE
feat: support aligning window controls to the left

### DIFF
--- a/src/uosc.conf
+++ b/src/uosc.conf
@@ -109,7 +109,8 @@ menu_type_to_search=yes
 # Can be: never, no-border, always
 top_bar=no-border
 top_bar_size=40
-top_bar_controls=yes
+# Can be: `no` (hide), left or right
+top_bar_controls=right
 # Can be: `no` (hide), `yes` (inherit title from mpv.conf), or a custom template string
 top_bar_title=yes
 # Template string to enable alternative top bar title. If alt title matches main title,

--- a/src/uosc/elements/TopBar.lua
+++ b/src/uosc/elements/TopBar.lua
@@ -316,7 +316,7 @@ function TopBar:render()
 				-- Title
 				local max_bx = title_bx - remaining_box_width - spacing
 				local rect_width = round(math.min(text_width(text, opts) + padding * 2, max_bx - title_ax))
-				local ax = left_aligned and max_bx - rect_width or title_ax
+				local ax = left_aligned and title_bx - rect_width or title_ax
 				local rect = {
 					ax = ax,
 					ay = title_ay,
@@ -333,7 +333,7 @@ function TopBar:render()
 				cursor:zone('primary_click', rect, function() mp.command('script-binding uosc/chapters') end)
 
 				-- Time
-				rect.ax = rect.bx + spacing
+				rect.ax = left_aligned and rect.ax - spacing - remaining_box_width or rect.bx + spacing
 				rect.bx = rect.ax + remaining_box_width
 				opts.clip = nil
 				ass:rect(rect.ax, rect.ay, rect.bx, rect.by, {

--- a/src/uosc/elements/TopBar.lua
+++ b/src/uosc/elements/TopBar.lua
@@ -294,7 +294,7 @@ function TopBar:render()
 				local padding_half = round(padding / 2)
 				local font_size = self.font_size * 0.8
 				local height = font_size * 1.3
-				local prefix, postfix = left_aligned and '' or ' ┘', left_aligned and ' ┘' or ''
+				local prefix, postfix = left_aligned and '' or '└ ', left_aligned and ' ┘' or ''
 				local text = prefix .. state.current_chapter.index .. ': ' .. state.current_chapter.title .. postfix
 				local next_chapter = state.chapters[state.current_chapter.index + 1]
 				local chapter_end = next_chapter and next_chapter.time or state.duration or 0

--- a/src/uosc/elements/TopBar.lua
+++ b/src/uosc/elements/TopBar.lua
@@ -249,7 +249,8 @@ function TopBar:render()
 					border_color = bg,
 					clip = string.format('\\clip(%d, %d, %d, %d)', self.ax, self.ay, title_bx, self.by),
 				}
-				local rect_width = math.min(round(text_width(main_title, opts) + padding * 2), title_bx - title_ax)
+				local rect_ideal_width = round(text_width(main_title, opts) + padding * 2)
+				local rect_width = math.min(rect_ideal_width, title_bx - title_ax)
 				local ax = left_aligned and title_bx - rect_width or title_ax
 				local by = self.by - bg_margin
 				local title_rect = {ax = ax, ay = title_ay, bx = ax + rect_width, by = by}
@@ -261,7 +262,9 @@ function TopBar:render()
 				ass:rect(title_rect.ax, title_rect.ay, title_rect.bx, title_rect.by, {
 					color = bg, opacity = visibility * config.opacity.title, radius = state.radius,
 				})
-				ass:txt(ax + padding, self.ay + (self.size / 2), 4, main_title, opts)
+				local align = left_aligned and rect_ideal_width == rect_width and 6 or 4
+				local x = align == 6 and title_rect.bx - padding or ax + padding
+				ass:txt(x, self.ay + (self.size / 2), align, main_title, opts)
 				title_ay = by + spacing
 			end
 
@@ -278,14 +281,17 @@ function TopBar:render()
 					border_color = bg,
 					opacity = visibility,
 				}
-				local rect_width = math.min(round(text_width(self.alt_title, opts) + padding * 2), title_bx - title_ax)
+				local rect_ideal_width = round(text_width(self.alt_title, opts) + padding * 2)
+				local rect_width = math.min(rect_ideal_width, title_bx - title_ax)
 				local ax = left_aligned and title_bx - rect_width or title_ax
 				local bx = ax + rect_width
 				opts.clip = string.format('\\clip(%d, %d, %d, %d)', title_ax, title_ay, bx, by)
 				ass:rect(ax, title_ay, bx, by, {
 					color = bg, opacity = visibility * config.opacity.title, radius = state.radius,
 				})
-				ass:txt(ax + padding, title_ay + height / 2, 4, self.alt_title, opts)
+				local align = left_aligned and rect_ideal_width == rect_width and 6 or 4
+				local x = align == 6 and bx - padding or ax + padding
+				ass:txt(x, title_ay + height / 2, align, self.alt_title, opts)
 				title_ay = by + spacing
 			end
 
@@ -315,7 +321,8 @@ function TopBar:render()
 
 				-- Title
 				local max_bx = title_bx - remaining_box_width - spacing
-				local rect_width = round(math.min(text_width(text, opts) + padding * 2, max_bx - title_ax))
+				local rect_ideal_width = round(text_width(text, opts) + padding * 2)
+				local rect_width = math.min(rect_ideal_width, max_bx - title_ax)
 				local ax = left_aligned and title_bx - rect_width or title_ax
 				local rect = {
 					ax = ax,
@@ -327,7 +334,9 @@ function TopBar:render()
 				ass:rect(rect.ax, rect.ay, rect.bx, rect.by, {
 					color = bg, opacity = visibility * config.opacity.title, radius = state.radius,
 				})
-				ass:txt(rect.ax + padding, rect.ay + height / 2, 4, text, opts)
+				local align = left_aligned and rect_ideal_width == rect_width and 6 or 4
+				local x = align == 6 and rect.bx - padding or rect.ax + padding
+				ass:txt(x, rect.ay + height / 2, align, text, opts)
 
 				-- Click action
 				cursor:zone('primary_click', rect, function() mp.command('script-binding uosc/chapters') end)

--- a/src/uosc/main.lua
+++ b/src/uosc/main.lua
@@ -51,7 +51,7 @@ defaults = {
 	top_bar = 'no-border',
 	top_bar_size = 40,
 	top_bar_persistency = '',
-	top_bar_controls = true,
+	top_bar_controls = 'right',
 	top_bar_title = 'yes',
 	top_bar_alt_title = '',
 	top_bar_alt_title_place = 'below',
@@ -125,6 +125,9 @@ if options.total_time and options.destination_time == 'playtime-remaining' then
 	options.destination_time = 'total'
 elseif not itable_index_of({'total', 'playtime-remaining', 'time-remaining'}, options.destination_time) then
 	options.destination_time = 'playtime-remaining'
+end
+if not itable_index_of({'left', 'right'}, options.top_bar_controls) then
+	options.top_bar_controls = nil
 end
 -- Ensure required environment configuration
 if options.autoload then mp.commandv('set', 'keep-open-pause', 'no') end

--- a/src/uosc/main.lua
+++ b/src/uosc/main.lua
@@ -127,7 +127,7 @@ elseif not itable_index_of({'total', 'playtime-remaining', 'time-remaining'}, op
 	options.destination_time = 'playtime-remaining'
 end
 if not itable_index_of({'left', 'right'}, options.top_bar_controls) then
-	options.top_bar_controls = nil
+	options.top_bar_controls = options.top_bar_controls == 'yes' and 'right' or nil
 end
 -- Ensure required environment configuration
 if options.autoload then mp.commandv('set', 'keep-open-pause', 'no') end


### PR DESCRIPTION
I don't like the way left alignment looks...

The calculation of `self.ax` isn't necessary anymore with the way clicks are handled now and afaik there is no benefit in accurately adjusting the boundary box, so for the sake of simplicity I've removed that instead of making it work with left alignment.

Closes #892