### PR TITLE
menus.lua: tweaks and fixes the display of the track menu

### DIFF
--- a/src/uosc/lib/menus.lua
+++ b/src/uosc/lib/menus.lua
@@ -109,6 +109,7 @@ function create_select_tracklist_type_menu_opener(menu_title, track_type, track_
 			items[#items].separator = true
 		end
 
+		local track_prop_index = tonumber(mp.get_property(track_prop))
 		local first_item_index = #items + 1
 		local active_index = nil
 		local disabled_item = nil
@@ -126,6 +127,7 @@ function create_select_tracklist_type_menu_opener(menu_title, track_type, track_
 		for _, track in ipairs(tracklist) do
 			if track.type == track_type then
 				local hint_values = {}
+				local track_selected = track.selected and track.id == track_prop_index
 				local function h(value) hint_values[#hint_values + 1] = value end
 
 				if track.lang then h(track.lang) end
@@ -148,10 +150,10 @@ function create_select_tracklist_type_menu_opener(menu_title, track_type, track_
 					title = (track.title and track.title or t('Track %s', track.id)),
 					hint = table.concat(hint_values, ', '),
 					value = track.id,
-					active = track.selected,
+					active = track_selected,
 				}
 
-				if track.selected then
+				if track_selected then
 					if disabled_item then disabled_item.active = false end
 					active_index = #items
 				end

--- a/src/uosc/lib/menus.lua
+++ b/src/uosc/lib/menus.lua
@@ -128,7 +128,7 @@ function create_select_tracklist_type_menu_opener(menu_title, track_type, track_
 				local hint_values = {}
 				local function h(value) hint_values[#hint_values + 1] = value end
 
-				if track.lang then h(track.lang:upper()) end
+				if track.lang then h(track.lang) end
 				if track['demux-h'] then
 					h(track['demux-w'] and (track['demux-w'] .. 'x' .. track['demux-h']) or (track['demux-h'] .. 'p'))
 				end


### PR DESCRIPTION
mpv upstream commit https://github.com/mpv-player/mpv/commit/ab3b174 has introduced support for BCP 47 language tags,
 and now track lang has uppercase and lowercase content.

Avoid showing the selection status of secondary subtitle in the subtitle menu at the same time.

current behavior of mian:
![image](https://github.com/tomasklaen/uosc/assets/61936050/161c273f-2260-47cb-8d8a-ed175ef032f4)
apply changes:
![image](https://github.com/tomasklaen/uosc/assets/61936050/c3bcad3c-87d8-4c44-a6e1-7be6da29c3d1)

