### PR TITLE
fix: buffered_time_threshold check

### DIFF
--- a/src/uosc/elements/Timeline.lua
+++ b/src/uosc/elements/Timeline.lua
@@ -373,14 +373,15 @@ function Timeline:render()
 	if text_opacity > 0 then
 		local time_opts = {size = self.font_size, opacity = text_opacity, border = 2 * state.scale}
 		-- Upcoming cache time
-		if state.cache_duration and options.buffered_time_threshold > 0
-			and state.cache_duration < options.buffered_time_threshold then
+		local cache_duration = state.cache_duration and state.cache_duration / state.speed or nil
+		if cache_duration and options.buffered_time_threshold > 0
+			and cache_duration < options.buffered_time_threshold then
 			local margin = 5 * state.scale
 			local x, align = fbx + margin, 4
 			local cache_opts = {
 				size = self.font_size * 0.8, opacity = text_opacity * 0.6, border = options.text_border * state.scale,
 			}
-			local human = round(state.cache_duration / state.speed) .. 's'
+			local human = round(cache_duration) .. 's'
 			local width = text_width(human, cache_opts)
 			local time_width = timestamp_width(state.time_human, time_opts)
 			local time_width_end = timestamp_width(state.destination_time_human, time_opts)


### PR DESCRIPTION
a7136337c852a51bf4a55da3fd69257171a40415 fixed the shown duration, but the threshold check wasn't adjusted and therefore still didn't behave the same as before 00737e1598da8756ac70f8199b022dc7cc09d43e.

3 commits for such a simple change... incredible