### PR TITLE
feat: show playlist files in the file navigation menu

### DIFF
--- a/src/uosc.conf
+++ b/src/uosc.conf
@@ -192,6 +192,7 @@ video_types=3g2,3gp,asf,avi,f4v,flv,h264,h265,m2ts,m4v,mkv,mov,mp4,mp4v,mpeg,mpg
 audio_types=aac,ac3,aiff,ape,au,cue,dsf,dts,flac,m4a,mid,midi,mka,mp3,mp4a,oga,ogg,opus,spx,tak,tta,wav,weba,wma,wv
 image_types=apng,avif,bmp,gif,j2k,jp2,jfif,jpeg,jpg,jxl,mj2,png,svg,tga,tif,tiff,webp
 subtitle_types=aqt,ass,gsub,idx,jss,lrc,mks,pgs,pjs,psb,rt,sbv,slt,smi,sub,sup,srt,ssa,ssf,ttxt,txt,usf,vt,vtt
+playlist_types=m3u,m3u8,pls,url,cue
 # Default open-file menu directory
 default_directory=~/
 # List hidden files when reading directories. Due to environment limitations, this currently only hides

--- a/src/uosc/main.lua
+++ b/src/uosc/main.lua
@@ -92,6 +92,7 @@ defaults = {
 	'aac,ac3,aiff,ape,au,cue,dsf,dts,flac,m4a,mid,midi,mka,mp3,mp4a,oga,ogg,opus,spx,tak,tta,wav,weba,wma,wv',
 	image_types = 'apng,avif,bmp,gif,j2k,jp2,jfif,jpeg,jpg,jxl,mj2,png,svg,tga,tif,tiff,webp',
 	subtitle_types = 'aqt,ass,gsub,idx,jss,lrc,mks,pgs,pjs,psb,rt,sbv,slt,smi,sub,sup,srt,ssa,ssf,ttxt,txt,usf,vt,vtt',
+	playlist_types = 'm3u,m3u8,pls,url,cue',
 	default_directory = '~/',
 	show_hidden_files = false,
 	use_trash = false,
@@ -187,7 +188,10 @@ config = {
 		audio = comma_split(options.audio_types),
 		image = comma_split(options.image_types),
 		subtitle = comma_split(options.subtitle_types),
-		media = comma_split(options.video_types .. ',' .. options.audio_types .. ',' .. options.image_types),
+		media = comma_split(options.video_types
+			.. ',' .. options.audio_types
+			.. ',' .. options.image_types
+			.. ',' .. options.playlist_types),
 		autoload = (function()
 			---@type string[]
 			local option_values = {}


### PR DESCRIPTION
So far the file navigation menu would only show media files and directories, but opening playlist files via that menu is a valid use case as well.

From a quick look at `demux_playlist.c` and a bit of testing, those seem to be the only playlist formats mpv supports.
mpv can also open `.txt` files as playlists, but they need to be provided via the `--playlist=<path>` argument and thus don't work here.

ref. https://github.com/tomasklaen/uosc/discussions/926