### PR TITLE
feat: use loadlist when opening playlists

### DIFF
--- a/src/uosc/lib/menus.lua
+++ b/src/uosc/lib/menus.lua
@@ -591,10 +591,11 @@ function open_open_file_menu()
 	menu = open_file_navigation_menu(
 		directory,
 		function(path, mods)
+			local command = has_any_extension(path, config.types.playlist) and 'loadlist' or 'loadfile'
 			if mods.ctrl then
-				mp.commandv('loadfile', path, 'append')
+				mp.commandv(command, path, 'append')
 			else
-				mp.commandv('loadfile', path)
+				mp.commandv(command, path)
 				Menu:close()
 			end
 		end,

--- a/src/uosc/main.lua
+++ b/src/uosc/main.lua
@@ -188,6 +188,7 @@ config = {
 		audio = comma_split(options.audio_types),
 		image = comma_split(options.image_types),
 		subtitle = comma_split(options.subtitle_types),
+		playlist = comma_split(options.playlist_types),
 		media = comma_split(options.video_types
 			.. ',' .. options.audio_types
 			.. ',' .. options.image_types


### PR DESCRIPTION
Opening a playlist with loadfile can lead to problems like autoload.lua populating the playlist with other files that were in the same directory as the playlist file.

To avoid that the command loadlist can be used to avoid having mpv treat the file like any other, just to notice during demuxing that it is a playlist.

ref. https://github.com/tomasklaen/uosc/pull/927#issuecomment-2210135586

@hooke007 You won't like that this is based on the file extension, but I don't know how else we would go about doing it. We could read the beginning of the file and deciding based on that, but I'd rather not do that unless it's _very_ important to do that. I've checked if we could do something via mime-type (e.g. `file --mime-type` on linux), but m3u8 playlists simply show up as plain text, so we'd have to treat all text files as playlists.