### PR TITLE
fix: use primary_click for chapter indicators

### DIFF
--- a/src/uosc/elements/Timeline.lua
+++ b/src/uosc/elements/Timeline.lua
@@ -317,7 +317,7 @@ function Timeline:render()
 					if chapter ~= hovered_chapter then draw_chapter(chapter.time, diamond_radius) end
 					local circle = {point = {x = t2x(chapter.time), y = fay - 1}, r = diamond_radius_hovered}
 					if visibility > 0 then
-						cursor:zone('primary_down', circle, function()
+						cursor:zone('primary_click', circle, function()
 							mp.commandv('seek', chapter.time, 'absolute+exact')
 						end)
 					end


### PR DESCRIPTION
Listening to `primary_down`, but not listening to the `primary_up` event leads to that `up` event getting forwarded. Listening to `primary_click` instead avoids that problem.

Seeking chapters now happens on button up instead of button down, but that shouldn't be a problem for anyone and makes their behavior consistent with other clickable UI elements.

ref. https://github.com/tomasklaen/uosc/discussions/931