### PR TITLE
feat: add char_conv option

### DIFF
--- a/src/uosc.conf
+++ b/src/uosc.conf
@@ -234,3 +234,7 @@ languages=slang,en
 #   window_border, top_bar, timeline, controls, volume,
 #   idle_indicator, audio_indicator, buffering_indicator, pause_indicator
 disable_elements=
+
+# Convert non-latin characters to latin for searching
+# Character get converted only if it is from one of `languages`
+char_conv=no

--- a/src/uosc/lib/char_conv.lua
+++ b/src/uosc/lib/char_conv.lua
@@ -3,12 +3,9 @@ require('lib/text')
 local char_dir = mp.get_script_directory() .. '/char-conv/'
 local data = {}
 
-local languages = get_languages()
-for i = #languages, 1, -1 do
-	lang = languages[i]
-	if (lang == 'en') then
-		data = {}
-	else
+if options.char_conv then
+	local languages = get_languages()
+	for _, lang in ipairs(languages) do
 		table_assign(data, get_locale_from_json(char_dir .. lang:lower() .. '.json'))
 	end
 end

--- a/src/uosc/main.lua
+++ b/src/uosc/main.lua
@@ -101,6 +101,7 @@ defaults = {
 	chapter_range_patterns = 'openings:オープニング;endings:エンディング',
 	languages = 'slang,en',
 	disable_elements = '',
+	char_conv = false,
 }
 options = table_copy(defaults)
 opt.read_options(options, 'uosc', function(changed_options)


### PR DESCRIPTION
Currently char_conv doesn't work if the first language in `languages` is `en`. This PR adds an option to enable it.

It is disabled by default and **BREAKS** the old behavior. The old users of this feature need to add following line to their `usoc.conf`:
```
char_conv=yes
```