### PR TITLE
fix: timeline when rebase-start-time=no

### DIFF
--- a/src/uosc/elements/Timeline.lua
+++ b/src/uosc/elements/Timeline.lua
@@ -450,7 +450,8 @@ function Timeline:render()
 				border_color = fg,
 				radius = state.radius,
 			})
-			mp.commandv('script-message-to', 'thumbfast', 'thumb', hovered_seconds, thumb_x, thumb_y)
+			local thumb_seconds = (state.rebase_start_time == false and state.start_time) and (hovered_seconds - state.start_time) or hovered_seconds
+			mp.commandv('script-message-to', 'thumbfast', 'thumb', thumb_seconds, thumb_x, thumb_y)
 			self.has_thumbnail, rendered_thumbnail = true, true
 			tooltip_anchor.ay = ay
 		end

--- a/src/uosc/main.lua
+++ b/src/uosc/main.lua
@@ -450,6 +450,12 @@ function update_fullormaxed()
 	cursor:leave()
 end
 
+function update_duration()
+	state.duration = state._duration and ((state.rebase_start_time == false and state.start_time)
+		and (state._duration + state.start_time) or state._duration)
+	update_human_times()
+end
+
 function update_human_times()
 	state.speed = state.speed or 1
 	if state.time then
@@ -723,7 +729,9 @@ mp.observe_property('playback-time', 'number', create_state_setter('time', funct
 	update_human_times()
 	select_current_chapter()
 end))
-mp.observe_property('duration', 'number', create_state_setter('duration', update_human_times))
+mp.observe_property('rebase-start-time', 'bool', create_state_setter('rebase_start_time', update_duration))
+mp.observe_property('demuxer-start-time', 'number', create_state_setter('start_time', update_duration))
+mp.observe_property('duration', 'number', create_state_setter('_duration', update_duration))
 mp.observe_property('speed', 'number', create_state_setter('speed', update_human_times))
 mp.observe_property('track-list', 'native', function(name, value)
 	-- checks the file dispositions


### PR DESCRIPTION
We would end up with a playback-time way past the reported duration on some files when using `--rebase-start-time=no`, which would break the timeline display and produce seeks that were outside the playable range of the video.

Sample generated with `streamlink -o lol.ts https://www.twitch.tv/rubius 1080p50`: https://0x0.st/XwrB.ts

Before
![lol ts_023847 200](https://github.com/user-attachments/assets/32e966d5-b949-4c28-9f70-00c2bb399d0e)
After
![lol ts_023847 200_](https://github.com/user-attachments/assets/15b6beb9-78ef-4425-8fda-54bf795f30aa)
