### PR TITLE
fix: replaces the deprecated wmic command

### DIFF
--- a/src/uosc/lib/menus.lua
+++ b/src/uosc/lib/menus.lua
@@ -388,13 +388,12 @@ function open_file_navigation_menu(directory_path, handle_activate, opts)
 				name = 'subprocess',
 				capture_stdout = true,
 				playback_only = false,
-				args = {'wmic', 'logicaldisk', 'get', 'name', '/value'},
+				args = {'fsutil', 'fsinfo', 'drives'},
 			})
 			local items, selected_index = {}, 1
 
 			if process.status == 0 then
-				for _, value in ipairs(split(process.stdout, '\n')) do
-					local drive = string.match(value, 'Name=([A-Z]:)')
+				for drive in process.stdout:gmatch("(%a:)\\") do
 					if drive then
 						local drive_path = normalize_path(drive)
 						items[#items + 1] = {


### PR DESCRIPTION
The wmic disabled by default since Win11 24H2
![image](https://github.com/user-attachments/assets/b30dd8a2-61d8-4c08-80b9-9b3ff992d9b9)
