### PR TITLE
fix: builtin osc-idlescreen flashing when mpv is launched in idle mode

### DIFF
--- a/src/uosc/main.lua
+++ b/src/uosc/main.lua
@@ -3,6 +3,8 @@ local uosc_version = '5.7.0'
 
 mp.commandv('script-message', 'uosc-version', uosc_version)
 
+mp.set_property('osc', 'no')
+
 assdraw = require('mp.assdraw')
 opt = require('mp.options')
 utils = require('mp.utils')
@@ -667,7 +669,6 @@ if options.click_threshold > 0 then
 	end
 end
 
-mp.observe_property('osc', 'bool', function(name, value) if value == true then mp.set_property('osc', 'no') end end)
 mp.register_event('file-loaded', function()
 	local path = normalize_path(mp.get_property_native('path'))
 	itable_delete_value(state.history, path)


### PR DESCRIPTION
with force-window=immediate and osc=yes

https://github.com/user-attachments/assets/336b83f8-3daf-48ee-ae94-661fbcd4acf3

Tested on MacOS, likely happens on other platforms too.

Because we disable the osc within the first run of the script, there are no chances for extra renders to go through.  
The previous approach was racy.
cf #736
