### PR TITLE
feat: working text cursor when editing search inputs

### DIFF
--- a/src/uosc/elements/Menu.lua
+++ b/src/uosc/elements/Menu.lua
@@ -13,7 +13,7 @@ local Element = require('elements/Element')
 ---@alias MenuStackChild MenuStackItem|MenuStack
 ---@alias MenuStackItem {title?: string; hint?: string; icon?: string; value: any; actions?: MenuAction[]; actions_place?: 'inside' | 'outside'; active?: boolean; keep_open?: boolean; selectable?: boolean; bold?: boolean; italic?: boolean; muted?: boolean; separator?: boolean; align?: 'left'|'center'|'right'; title_width: number; hint_width: number; ass_safe_hint?: string}
 ---@alias Fling {y: number, distance: number, time: number, easing: fun(x: number), duration: number, update_cursor?: boolean}
----@alias Search {query: string; timeout: unknown; min_top: number; max_width: number; source: {width: number; top: number; scroll_y: number; selected_index?: integer; items?: MenuStackChild[]}}
+---@alias Search {query: string; cursor: number; timeout: unknown; min_top: number; max_width: number; source: {width: number; top: number; scroll_y: number; selected_index?: integer; items?: MenuStackChild[]}}
 
 ---@alias MenuEventActivate {type: 'activate'; index: number; value: any; action?: string; modifiers?: string; alt: boolean; ctrl: boolean; shift: boolean; is_pointer: boolean; keep_open?: boolean; menu_id: string;}
 ---@alias MenuEventMove {type: 'move'; from_index: number; to_index: number; menu_id: string;}
@@ -266,7 +266,10 @@ function Menu:update(data)
 	end
 	-- Apply search suggestions
 	for _, menu in ipairs(new_menus) do
-		if menu.search_suggestion then menu.search.query = menu.search_suggestion end
+		if menu.search_suggestion then
+			menu.search.query = menu.search_suggestion
+			menu.search.cursor = #menu.search_suggestion
+		end
 	end
 	for _, menu in ipairs(self.all) do
 		if menu.search then
@@ -787,10 +790,10 @@ function Menu:paste()
 			},
 		})
 	elseif menu.search then
-		self:search_query_update(menu.search.query .. payload)
+		self:search_query_replace(menu.search.query .. payload)
 	elseif menu.search_style ~= 'disabled' then
 		self:search_start(menu.id)
-		self:search_query_update(payload, menu.id)
+		self:search_query_replace(payload, menu.id)
 	end
 end
 
@@ -870,13 +873,49 @@ function Menu:search_submit(menu_id)
 	end
 end
 
+-- Move search query cursor by an amount.
+---@param amount number `<0` for left, `>0` for right.
+---@param word_mode? boolean Move by words/segments. Overwrites amount, but respects its direction.
+function Menu:search_cursor_move(amount, word_mode)
+	local menu = self:get_menu()
+	if not menu or not menu.search then return end
+	local query, cursor = menu.search.query, menu.search.cursor
+	if word_mode then
+		menu.search.cursor = find_string_segment_bound(query, cursor, amount) + (amount < 0 and -1 or 0)
+	else
+		menu.search.cursor = clamp(0, cursor + amount, #query)
+	end
+	request_render()
+end
+
 ---@param query string
 ---@param menu_id? string
 ---@param immediate? boolean
-function Menu:search_query_update(query, menu_id, immediate)
+function Menu:search_query_replace(query, menu_id, immediate)
 	local menu = self:get_menu(menu_id)
 	if not menu or not menu.search then return end
 	menu.search.query = query
+	menu.search.cursor = #query
+	self:search_trigger(menu_id, immediate)
+end
+
+-- Insert string into search query at cursor.
+---@param str string
+---@param menu_id? string
+function Menu:search_query_insert(str, menu_id)
+	local menu = self:get_menu(menu_id)
+	if not menu or not menu.search then return end
+	local query, cursor = menu.search.query, menu.search.cursor
+	local head, tail = string.sub(query, 1, cursor), string.sub(query, cursor + 1)
+	menu.search.query = head .. str .. tail
+	menu.search.cursor = cursor + #str
+	self:search_trigger(menu_id)
+end
+
+-- Trigger menu search callbacks, should be called after any query changes.
+function Menu:search_trigger(menu_id, immediate)
+	local menu = self:get_menu(menu_id)
+	if not menu or not menu.search then return end
 	if menu.search_debounce ~= 'submit' then
 		if menu.search.timeout then menu.search.timeout:kill() end
 		if menu.search.timeout and not immediate then
@@ -894,33 +933,74 @@ end
 
 ---@param event? string
 ---@param word_mode? boolean Delete by words.
-function Menu:search_backspace(event, word_mode)
-	local pos, old_query = #self.current.search.query, self.current.search.query
-	local is_palette = self.current.search_style == 'palette'
-	if word_mode and #old_query > 1 then
-		local word_pat, other_pat = '[^%c%s%p]+$', '[%c%s%p]+$'
-		local init_pat = old_query:sub(#old_query):match(word_pat) and word_pat or other_pat
-		-- First we match all same type consecutive chars at the end
-		local tail = old_query:match(init_pat) or ''
-		-- If there's only one, we extend the tail with opposite type chars
-		if tail and #tail == 1 then
-			tail = tail .. old_query:sub(1, #old_query - #tail):match(init_pat == word_pat and other_pat or word_pat)
+function Menu:search_query_backspace(event, word_mode)
+	local search = self.current.search
+	if not search then return end
+
+	local cursor, old_query = search.cursor, search.query
+	local head, tail = string.sub(old_query, 1, cursor), string.sub(old_query, cursor + 1)
+
+	if word_mode then
+		cursor = find_string_segment_bound(head, cursor, -1) - 1
+	elseif cursor > 0 then
+		-- The while loop is for skipping utf8 continuation bytes
+		while cursor > 1 and old_query:byte(cursor) >= 0x80 and old_query:byte(cursor) <= 0xbf do
+			cursor = cursor - 1
 		end
-		pos = pos - #tail
+		cursor = cursor - 1
+	end
+
+	local new_query = head:sub(1, cursor) .. tail
+	if new_query ~= old_query then
+		search.query = new_query
+		search.cursor = math.max(0, cursor)
+		self:search_trigger()
+	end
+
+	if #new_query == 0 then
+		local is_palette = self.current.search_style == 'palette'
+		if not is_palette and self.type_to_search then
+			self:search_cancel()
+		elseif is_palette and event ~= 'repeat' then
+			self:back()
+		end
+	end
+end
+
+---@param event? string
+---@param word_mode? boolean Delete by words.
+function Menu:search_query_delete(event, word_mode)
+	local search = self.current.search
+	if not search then return end
+
+	local cursor, old_query = search.cursor, search.query
+	local head, tail = string.sub(old_query, 1, cursor), string.sub(old_query, cursor + 1)
+	local tail_cursor = 1
+
+	if word_mode then
+		tail_cursor = find_string_segment_bound(tail, 0, 1) + 1
 	else
 		-- The while loop is for skipping utf8 continuation bytes
-		while pos > 1 and old_query:byte(pos) >= 0x80 and old_query:byte(pos) <= 0xbf do
-			pos = pos - 1
+		while tail_cursor < #tail and tail:byte(tail_cursor) >= 0x80 and tail:byte(tail_cursor) <= 0xbf do
+			tail_cursor = tail_cursor + 1
 		end
-		pos = pos - 1
+		tail_cursor = tail_cursor + 1
 	end
-	local new_query = old_query:sub(1, pos)
-	if new_query ~= old_query and (is_palette or not self.type_to_search or pos > 0) then
-		self:search_query_update(new_query)
-	elseif not is_palette and self.type_to_search then
-		self:search_cancel()
-	elseif is_palette and event ~= 'repeat' then
-		self:back()
+
+	local new_query = head .. tail:sub(tail_cursor)
+	if new_query ~= old_query then
+		search.query = new_query
+		search.cursor = #head
+		self:search_trigger()
+	end
+
+	if #new_query == 0 then
+		local is_palette = self.current.search_style == 'palette'
+		if not is_palette and self.type_to_search then
+			self:search_cancel()
+		elseif is_palette and event ~= 'repeat' then
+			self:back()
+		end
 	end
 end
 
@@ -936,7 +1016,7 @@ function Menu:search_text_input(info)
 			if key_text == 'DEC' then key_text = '.' end
 		end
 		if not menu.search then self:search_start() end
-		self:search_query_update(menu.search.query .. key_text)
+		self:search_query_insert(key_text)
 	end
 end
 
@@ -944,13 +1024,13 @@ end
 function Menu:search_cancel(menu_id)
 	local menu = self:get_menu(menu_id)
 	if not menu or not menu.search or menu.search_style == 'palette' then
-		self:search_query_update('', menu_id)
+		self:search_query_replace('', menu_id)
 		return
 	end
 	if state.ime_active == false then
 		mp.set_property_bool('input-ime', false)
 	end
-	self:search_query_update('', menu_id, true)
+	self:search_query_replace('', menu_id, true)
 	menu.search = nil
 	self:search_ensure_key_bindings()
 	self:update_dimensions()
@@ -974,6 +1054,7 @@ function Menu:search_init(menu_id)
 	end
 	menu.search = {
 		query = '',
+		cursor = 0,
 		timeout = timeout,
 		min_top = menu.top,
 		max_width = menu.width,
@@ -1003,7 +1084,7 @@ function Menu:search_clear_query(menu_id)
 	if not self.current.search_style == 'palette' and self.type_to_search then
 		self:search_cancel(menu_id)
 	else
-		self:search_query_update('', menu_id)
+		self:search_query_replace('', menu_id)
 	end
 end
 
@@ -1083,7 +1164,7 @@ function Menu:handle_shortcut(shortcut, info)
 
 	if info.event == 'up' then return end
 
-	if (key == 'enter' and selected_item) or (id == 'right' and is_submenu) then
+	if (key == 'enter' and selected_item) or (id == 'right' and is_submenu and not menu.search) then
 		self:activate_selected_item(shortcut)
 	elseif id == 'enter' and menu.search and menu.search_debounce == 'submit' then
 		self:search_submit()
@@ -1092,6 +1173,14 @@ function Menu:handle_shortcut(shortcut, info)
 	elseif id == 'pgup' or id == 'pgdwn' then
 		local items_per_page = round((menu.height / self.scroll_step) * 0.4)
 		self:navigate_by_offset(items_per_page * (id == 'pgup' and -1 or 1))
+	elseif menu.search and (id == 'left' or id == 'ctrl+left') then
+		self:search_cursor_move(-1, modifiers == 'ctrl')
+	elseif menu.search and (id == 'right' or id == 'ctrl+right') then
+		self:search_cursor_move(1, modifiers == 'ctrl')
+	elseif menu.search and id == 'home' then
+		self:search_cursor_move(-math.huge)
+	elseif menu.search and id == 'end' then
+		self:search_cursor_move(math.huge)
 	elseif id == 'home' or id == 'end' then
 		self:navigate_by_offset(id == 'home' and -math.huge or math.huge)
 	elseif id == 'shift+tab' then
@@ -1125,11 +1214,13 @@ function Menu:handle_shortcut(shortcut, info)
 			if modifiers == 'shift' then
 				self:search_clear_query()
 			elseif not modifiers or modifiers == 'ctrl' then
-				self:search_backspace(info.event, modifiers == 'ctrl')
+				self:search_query_backspace(info.event, modifiers == 'ctrl')
 			end
 		elseif not modifiers and info.event ~= 'repeat' then
 			self:back()
 		end
+	elseif menu.search and (id == 'del' or id == 'ctrl+del') then
+		self:search_query_delete(info.event, modifiers == 'ctrl')
 	elseif key == 'mbtn_back' then
 		self:back()
 	elseif id == 'ctrl+v' then
@@ -1538,16 +1629,23 @@ function Menu:render()
 				})
 
 				-- Query/Placeholder
+				local cursor_height_half, cursor_thickness = round(self.font_size * 0.6), round(self.font_size / 12)
+				local cursor_ax = rect.bx + 1
 				if menu.search.query ~= '' then
-					-- Add a ZWNBSP suffix to prevent libass from trimming trailing spaces
-					local query = ass_escape(menu.search.query) .. '\239\187\191'
-					ass:txt(rect.bx, rect.cy, 6, query, {
+					local opts = {
 						size = self.font_size,
 						color = bgt,
 						wrap = 2,
 						opacity = menu_opacity,
 						clip = '\\clip(' .. icon_rect.bx .. ',' .. rect.ay .. ',' .. rect.bx .. ',' .. rect.by .. ')',
-					})
+					}
+					local query, cursor = menu.search.query, menu.search.cursor
+					-- Add a ZWNBSP suffix to prevent libass from trimming trailing spaces
+					local head = ass_escape(string.sub(query, 1, cursor)) .. '\239\187\191'
+					local tail = ass_escape(string.sub(query, cursor + 1)) .. '\239\187\191'
+					cursor_ax = math.max(round(cursor_ax - text_width(tail, opts)), rect.cx)
+					ass:txt(cursor_ax, rect.cy, 6, head, opts)
+					ass:txt(cursor_ax, rect.cy, 4, tail, opts)
 				else
 					local placeholder = (menu.search_style == 'palette' and menu.ass_safe_title)
 						and menu.ass_safe_title
@@ -1571,8 +1669,7 @@ function Menu:render()
 				local input_is_blurred = menu.search_debounce == 'submit' and menu.selected_index
 
 				-- Cursor
-				local cursor_height_half, cursor_thickness = round(self.font_size * 0.6), round(self.font_size / 12)
-				local cursor_ax, cursor_bx = rect.bx + 1, rect.bx + 1 + cursor_thickness
+				local cursor_bx = cursor_ax + cursor_thickness
 				ass:rect(cursor_ax, rect.cy - cursor_height_half, cursor_bx, rect.cy + cursor_height_half, {
 					color = fg,
 					opacity = menu_opacity * (input_is_blurred and 0.5 or 1),

--- a/src/uosc/lib/text.lua
+++ b/src/uosc/lib/text.lua
@@ -513,3 +513,34 @@ do
 		return initials
 	end
 end
+
+-- Returns the index of the beginning or end of the current word/segment in a string.
+---@param str string String to search in.
+---@param cursor number Where in the string to start searching.
+---@param direction number `1` to search forward, `-1` backward.
+function find_string_segment_bound(str, cursor, direction)
+	if #str < 2 then return #str end
+	cursor = math.max(1, math.min(cursor, #str))
+	local head, tail = string.sub(str, 1, cursor), string.sub(str, cursor + 1)
+	if direction < 0 then
+		local word_pat, other_pat = '[^%c%s%p]+$', '[%c%s%p]+$'
+		local pat = head:sub(#head):match(word_pat) and word_pat or other_pat
+		-- First we match all same type consecutive chars starting at cursor
+		local segment = head:match(pat) or ''
+		-- If there's only one, we extend the segment with opposite type chars
+		if segment and #segment == 1 then
+			local match = head:sub(1, #head - #segment):match(pat == word_pat and other_pat or word_pat)
+			segment = (match or '') .. segment
+		end
+		return cursor - #segment + 1
+	else
+		local word_pat, other_pat = '^[^%c%s%p]+', '^[%c%s%p]+'
+		local pat = tail:sub(1, 1):match(word_pat) and word_pat or other_pat
+		local segment = tail:match(pat) or ''
+		if segment and #segment == 1 then
+			local match = tail:sub(#segment):match(pat == word_pat and other_pat or word_pat)
+			segment = segment .. (match or '')
+		end
+		return cursor + #segment
+	end
+end


### PR DESCRIPTION
This ads a working cursor when editing menu search input fields. I'd be surprised if there weren't some edge case issues I missed with all the different menu & search types we have, but as far as I can tell, at the moment there's only one small issue:

When there's a space in front of the cursor, our `text_width()` measuring misbehaves and overshoots the measurement of the width of the query tail (the part after the cursor), so the cursor position and the whole query jumps around, see below.

![cursor_text_width](https://github.com/user-attachments/assets/bac7bdb5-d892-422e-99e8-a31559034e16)

I've tried giving it a quick look but couldn't find an obvious fix for this. maybe @christoph-heinrich could look at it? Either way, it's still better than nothing and I wouldn't mind merging it as is.

closes #766