### PR TITLE
fix: cursor in search inputs is not moved correctly by utf-8 characters

### DIFF
--- a/src/uosc/elements/Menu.lua
+++ b/src/uosc/elements/Menu.lua
@@ -883,7 +883,18 @@ function Menu:search_cursor_move(amount, word_mode)
 	if word_mode then
 		menu.search.cursor = find_string_segment_bound(query, cursor, amount) + (amount < 0 and -1 or 0)
 	else
-		menu.search.cursor = clamp(0, cursor + amount, #query)
+		local move = amount > 0 and utf8_next or utf8_prev
+		local step_count = 0
+		local limit = math.abs(amount)
+
+		while step_count < limit do
+			local next_cursor = move(query, cursor)
+			if next_cursor == cursor then break end
+			cursor = next_cursor
+			step_count = step_count + 1
+		end
+
+		menu.search.cursor = clamp(0, cursor, #query)
 	end
 	request_render()
 end

--- a/src/uosc/lib/text.lua
+++ b/src/uosc/lib/text.lua
@@ -91,6 +91,33 @@ function utf8_length(str)
 	return str_length
 end
 
+---Get the next character in an utf-8 encoded string
+---@param str string
+---@param i integer
+---@return integer
+function utf8_next(str, i)
+	if i >= #str then return #str end
+	local len = utf8_char_bytes(str, i + 1)
+	return math.min(i + len, #str)
+end
+
+---Get the previous character in an utf-8 encoded string
+---@param str string
+---@param i integer
+---@return integer
+function utf8_prev(str, i)
+	if i <= 0 then return 0 end
+	local pos = 1
+	local last_valid = 0
+	while pos <= #str do
+		local len = utf8_char_bytes(str, pos)
+		if pos > i then break end
+		last_valid = pos - 1
+		pos = pos + len
+	end
+	return last_valid
+end
+
 ---Extract Unicode code point from utf-8 character at index i in str
 ---@param str string
 ---@param i integer


### PR DESCRIPTION
By the way, the `search_query_delete` function doesn't work properly.