### PR TITLE
fix: menu search cursor position when in front of a space

### DIFF
--- a/src/uosc/elements/Menu.lua
+++ b/src/uosc/elements/Menu.lua
@@ -1653,8 +1653,9 @@ function Menu:render()
 					local query, cursor = menu.search.query, menu.search.cursor
 					-- Add a ZWNBSP suffix to prevent libass from trimming trailing spaces
 					local head = ass_escape(string.sub(query, 1, cursor)) .. '\239\187\191'
-					local tail = ass_escape(string.sub(query, cursor + 1)) .. '\239\187\191'
-					cursor_ax = math.max(round(cursor_ax - text_width(tail, opts)), rect.cx)
+					local tail_no_escape = string.sub(query, cursor + 1)
+					local tail = ass_escape(tail_no_escape) .. '\239\187\191'
+					cursor_ax = math.max(round(cursor_ax - text_width(tail_no_escape, opts)), rect.cx)
 					ass:txt(cursor_ax, rect.cy, 6, head, opts)
 					ass:txt(cursor_ax, rect.cy, 4, tail, opts)
 				else


### PR DESCRIPTION
ass_escape() replaces leading spaces with '\h' (two characters), which led to the visible width of tail not lining up with the estimated one.

ref. https://github.com/tomasklaen/uosc/pull/1094