### PR TITLE
fix: selecting overlapping chapter indicators in timeline

### DIFF
--- a/src/uosc/elements/Timeline.lua
+++ b/src/uosc/elements/Timeline.lua
@@ -325,7 +325,7 @@ function Timeline:render()
 				for i, chapter in ipairs(state.chapters) do
 					if chapter ~= hovered_chapter then draw_chapter(chapter.time, diamond_radius) end
 					local circle = {point = {x = t2x(chapter.time), y = fay - 1}, r = diamond_radius_hovered}
-					if visibility > 0 then
+					if visibility > 0 and chapter == hovered_chapter then
 						cursor:zone('primary_down', circle, function()
 							mp.commandv('seek', chapter.time, 'absolute+exact')
 						end)


### PR DESCRIPTION
The overlap happens quite often on very long youtube music videos, or when you squish the mpv window too much.