### PR TITLE
Pseudo labels

### DIFF
--- a/src/uosc/elements/Button.lua
+++ b/src/uosc/elements/Button.lua
@@ -48,7 +48,7 @@ function Button:render()
 	if is_hover and is_clickable and background_opacity < 0.3 then background_opacity = 0.3 end
 
 	-- Background
-	if background_opacity > 0 then
+	if background_opacity > 0 and (self.icon ~= '') then
 		ass:rect(self.ax, self.ay, self.bx, self.by, {
 			color = (self.active or not is_hover) and background or foreground,
 			radius = state.radius,
@@ -67,6 +67,9 @@ function Button:render()
 		local badge_width = text_width(self.badge, badge_opts)
 		local width, height = math.ceil(badge_width + (badge_font_size / 7) * 2), math.ceil(badge_font_size * 0.93)
 		local bx, by = self.bx - 1, self.by - 1
+		-- if no icon, treat badge as lable and increse height a bit and center text
+		by = self.icon == '' and round((self.ay + self.by + height)/2) or self.by - 1
+		bx = self.icon == '' and round((self.ax + self.bx + width )/2) or self.bx - 1
 		ass:rect(bx - width, by - height, bx, by, {
 			color = foreground,
 			radius = state.radius,


### PR DESCRIPTION
**Improves button behavior based on icon presence.**  
- Disables background hover when the button lacks an icon.  
- Centers all iconless buttons—this is acceptable because we only want iconless buttons in two cases:  
  1. **Invisible buttons**, where centering is irrelevant (useful for hiding without layout changes).  
  2. **Pseudo labels**, where centering improves visual alignment.  

**Note:** Iconless buttons can only be created via the **button API**. Buttons generated through **uosc.conf** cannot be iconless (no changes for normal user).

Normal Buttons:
<img width="1920" height="1079" alt="without_button_adjustment" src="https://github.com/user-attachments/assets/bb7a9675-f3a6-4fda-ae56-75d5ad19307a" />
With adjustments and hidden background:
<img width="1920" height="1079" alt="with_button_adjustment" src="https://github.com/user-attachments/assets/ac4254e2-8530-4dbf-a902-973d97f0be60" />

I tested it a few months and had no problems, even if the spacing must be done somewhat manually. But is not really a big issue as long as only short information is put into the "label".
