### PR TITLE
feat: add autohide_ignore_dragging option

### DIFF
--- a/src/uosc.conf
+++ b/src/uosc.conf
@@ -181,6 +181,12 @@ time_precision=0
 buffered_time_threshold=60
 # Hide UI when mpv autohides the cursor. Timing is controlled by `cursor-autohide` in `mpv.conf` (in milliseconds).
 autohide=no
+# Allow UI to hide even when something prevents window dragging.
+# Normally, if a UI element disables window dragging (e.g. clickable controls),
+# cursor autohide is also disabled to keep the UI visible while interacting.
+# Enabling this option overrides that behaviour and hides the UI according to
+# the `cursor-autohide` timing in `mpv.conf` regardless of dragging prevention.
+autohide_ignore_dragging = no
 # Can be: flash, static, manual (controlled by flash-pause-indicator and decide-pause-indicator commands)
 pause_indicator=flash
 # Sizes to list in stream quality menu

--- a/src/uosc/lib/cursor.lua
+++ b/src/uosc/lib/cursor.lua
@@ -374,7 +374,7 @@ function cursor:leave() self:move(math.huge, math.huge) end
 
 function cursor:is_autohide_allowed()
 	return options.autohide and (not self.autohide_fs_only or state.fullscreen)
-		and not self.is_dragging_prevented
+		and (not self.is_dragging_prevented or options.autohide_ignore_dragging)
 		and not Menu:is_open()
 end
 mp.observe_property('cursor-autohide-fs-only', 'bool', function(_, val) cursor.autohide_fs_only = val end)

--- a/src/uosc/main.lua
+++ b/src/uosc/main.lua
@@ -81,6 +81,7 @@ defaults = {
 	time_precision = 0,
 	font_bold = false,
 	autohide = false,
+	autohide_ignore_dragging = false,
 	buffered_time_threshold = 60,
 	pause_indicator = 'flash',
 	stream_quality_options = '4320,2160,1440,1080,720,480,360,240,144',


### PR DESCRIPTION
### Summary
This adds the autohide_ignore_dragging option, allowing the OSC to follow mpv’s cursor-autohide timing even if a UI element has disabled window dragging (e.g. when the cursor is over clickable controls).

### Motivation
On multi-monitor setups, especially when the player is displayed on a secondary screen, the system cursor can unexpectedly “jump” or stay positioned over the OSC — often directly on a button or in the corner.
In such cases, is_dragging_prevented is true, and the current logic prevents autohide, leaving the OSC permanently visible until the cursor is moved manually.

This option provides a way to override that safety check so OSC hides automatically regardless of dragging prevention.