### PR TITLE
feat: display youtube heatmap on timeline

### DIFF
--- a/src/uosc.conf
+++ b/src/uosc.conf
@@ -14,6 +14,8 @@ timeline_border=1
 timeline_step=5
 # Render cache indicators for streaming content
 timeline_cache=yes
+# Render heatmap for youtube videos. Available: overlay, above, no
+timeline_heatmap=overlay
 
 # When to display an always visible progress bar (minimized timeline). Can be: windowed, fullscreen, always, never
 # Can also be toggled on demand with `toggle-progress` command.
@@ -152,11 +154,11 @@ text_border=1.2
 # Border radius of buttons, menus, and all other rectangles
 border_radius=4
 # A comma delimited list of color overrides in RGB HEX format. Defaults:
-# foreground=ffffff,foreground_text=000000,background=000000,background_text=ffffff,curtain=111111,success=a5e075,error=ff616e,match=69c5ff
+# foreground=ffffff,foreground_text=000000,background=000000,background_text=ffffff,curtain=111111,success=a5e075,error=ff616e,match=69c5ff,heatmap=00adee
 color=
 # A comma delimited list of opacity overrides for various UI element backgrounds and shapes.
 # This does not affect any text, which is always rendered fully opaque. Defaults:
-# timeline=0.9,position=1,chapters=0.8,slider=0.9,slider_gauge=1,controls=0,speed=0.6,menu=1,submenu=0.4,border=1,title=1,tooltip=1,thumbnail=1,curtain=0.8,idle_indicator=0.8,audio_indicator=0.5,buffering_indicator=0.3,playlist_position=0.8
+# timeline=0.9,position=1,chapters=0.8,slider=0.9,slider_gauge=1,controls=0,speed=0.6,menu=1,submenu=0.4,border=1,title=1,tooltip=1,thumbnail=1,curtain=0.8,idle_indicator=0.8,audio_indicator=0.5,buffering_indicator=0.3,playlist_position=0.8,heatmap=0.4
 opacity=
 # A comma delimited list of features to refine at a cost of some performance impact.
 # text_width - Use a more accurate text width measurement that measures each text string individually

--- a/src/uosc/lib/utils.lua
+++ b/src/uosc/lib/utils.lua
@@ -221,6 +221,37 @@ function get_ray_to_rectangle_distance(ax, ay, bx, by, rect)
 	return closest
 end
 
+-- Converts a flat table of points to a smooth curve using Catmull-Rom to Bezier conversion.
+---@param points number[] Flat table: x1, y1, x2, y2, ...
+---@return number[] Flat table: start point followed by segment entries cp1x, cp1y, cp2x, cp2y, px, py, ...
+function points_to_bezier(points)
+	if not points or #points < 4 then return {} end
+	local function catmullrom_to_bezier(p0x, p0y, p1x, p1y, p2x, p2y, p3x, p3y)
+		local cp1x = p1x + (p2x - p0x) / 6
+		local cp1y = p1y + (p2y - p0y) / 6
+		local cp2x = p2x - (p3x - p1x) / 6
+		local cp2y = p2y - (p3y - p1y) / 6
+		return cp1x, cp1y, cp2x, cp2y
+	end
+	-- Helper to get x, y from flat table
+	local function get_xy(i)
+		return points[i * 2 - 1], points[i * 2]
+	end
+	local curve = {points[1], points[2]}
+	local xy_pairs = #points / 2
+	for i = 1, xy_pairs - 1 do
+		local p0x, p0y = get_xy(math.max(i - 1, 1))
+		local p1x, p1y = get_xy(i)
+		local p2x, p2y = get_xy(i+1)
+		local p3x, p3y = get_xy(math.min(i + 2, xy_pairs))
+		local cp1x, cp1y, cp2x, cp2y = catmullrom_to_bezier(p0x, p0y, p1x, p1y, p2x, p2y, p3x, p3y)
+		local n = #curve
+		curve[n+1], curve[n+2], curve[n+3], curve[n+4], curve[n+5], curve[n+6] =
+			cp1x, cp1y, cp2x, cp2y, p2x, p2y
+	end
+	return curve
+end
+
 -- Extracts the properties used by property expansion of that string.
 ---@param str string
 ---@param res { [string] : boolean } | nil
@@ -934,6 +965,42 @@ function set_clipboard(payload)
 		mp.commandv('show-text', t('Copied to clipboard') .. ': ' .. payload, 3000)
 	end
 	return data and data.payload
+end
+
+-- Returns Youtube heatmap data if available.
+---@return number[]|nil Flat table of normalized points (0–1)
+function load_youtube_heatmap()
+	if not state.path or not is_protocol(state.path) then return end
+	-- Match mpv's ytdl whitelist
+	if not (state.path:match('^https?://%w+%.youtube%.com/') or
+			state.path:match('^https?://youtube%.com/') or
+			state.path:match('^https?://youtu%.be/')) then return end
+
+	local r = mp.get_property_native('user-data/mpv/ytdl/json-subprocess-result')
+	local ytdl_result = r and utils.parse_json(r.stdout)
+	if ytdl_result and ytdl_result.heatmap then
+		local data = ytdl_result.heatmap
+		local max_val = 0
+		local vid_length = data[#data].end_time
+		for _, seg in ipairs(data) do
+			max_val = math.max(max_val, seg.value)
+		end
+		-- Normalize and clamp to avoid gaps in heatmap
+		local is_above = options.timeline_heatmap == 'above'
+		local min_height, graph_height = 4, is_above and 40 or options.timeline_size
+		local max_norm_y = 1 - (min_height / graph_height)
+		local norm = {0, 1}
+		for _, seg in ipairs(data) do
+			local center_time = (seg.start_time + seg.end_time) / 2
+			local norm_x = center_time / vid_length
+			local norm_y = math.min(max_norm_y, 1 - (seg.value / max_val))
+			norm[#norm + 1], norm[#norm + 2] = norm_x, norm_y
+		end
+		-- Add final anchor
+		norm[#norm + 1], norm[#norm + 2] = 1, max_norm_y
+		norm[#norm + 1], norm[#norm + 2] = 1, 1
+		return points_to_bezier(norm)
+	end
 end
 
 --[[ RENDERING ]]

--- a/src/uosc/main.lua
+++ b/src/uosc/main.lua
@@ -27,6 +27,7 @@ defaults = {
 	timeline_border = 1,
 	timeline_step = '5',
 	timeline_cache = true,
+	timeline_heatmap = 'overlay',
 
 	controls =
 	'menu,gap,<video,audio>subtitles,<has_many_audio>audio,<has_many_video>video,<has_many_edition>editions,<stream>stream-quality,gap,space,<video,audio>speed,space,shuffle,loop-playlist,loop-file,gap,prev,items,next,gap,fullscreen',
@@ -145,6 +146,7 @@ local config_defaults = {
 		success = serialize_rgba('a5e075').color,
 		error = serialize_rgba('ff616e').color,
 		match = serialize_rgba('69c5ff').color,
+		heatmap = serialize_rgba('00adee').color,
 	},
 	opacity = {
 		timeline = 0.9,
@@ -165,6 +167,7 @@ local config_defaults = {
 		audio_indicator = 0.5,
 		buffering_indicator = 0.3,
 		playlist_position = 0.8,
+		heatmap = 0.4,
 	},
 }
 config = {


### PR DESCRIPTION
All the interactions with other options that i found are handled, so at this point this is as much done as i’m capable of.

I know the goal is to keep the config minimal, but in the end i've chosen to include the mentioned positioning for users who use a low `timeline_size` value but still want to see the heatmap. In that case, the heatmap uses the default youtube height, which coincidentally matches uosc's default timeline `40` size, so that's nice.

The `timeline_heatmap` option could still be removed, but turning it off through opacity options felt a bit convoluted.

closes #832