### PR TITLE
fix: incorrect anchoring on final heatmap point

### DIFF
--- a/src/uosc/lib/utils.lua
+++ b/src/uosc/lib/utils.lua
@@ -136,8 +136,8 @@ end
 function get_point_to_rectangle_proximity(point, rect)
 	local dx = math.max(rect.ax - point.x, point.x - rect.bx)
 	local dy = math.max(rect.ay - point.y, point.y - rect.by)
-    local distance = math.sqrt(math.max(0, dx)^2 + math.max(0, dy)^2)
-    return distance + math.min(0, math.max(dx, dy))
+	local distance = math.sqrt(math.max(0, dx)^2 + math.max(0, dy)^2)
+	return distance + math.min(0, math.max(dx, dy))
 end
 
 ---@param point_a Point
@@ -999,7 +999,8 @@ function load_youtube_heatmap()
 			norm[#norm + 1], norm[#norm + 2] = norm_x, norm_y
 		end
 		-- Add final anchor
-		norm[#norm + 1], norm[#norm + 2] = 1, max_norm_y
+		local last_y = math.min(max_norm_y, 1 - (data[#data].value / max_val))
+		norm[#norm + 1], norm[#norm + 2] = 1, last_y
 		norm[#norm + 1], norm[#norm + 2] = 1, 1
 		return points_to_bezier(norm)
 	end


### PR DESCRIPTION
Somehow i managed to miss it.

___

On top of that, this exposed an issue:

<img width="603" height="147" alt="overshoot" src="https://github.com/user-attachments/assets/fe4acacc-19a4-43ec-84ac-f1e5d367a32a" />


While we normalize the points they can still overshoot while creating control points for a smooth curve:

$cp_1^y = 0.900000 + \frac{0.900000 - 0.012372}{6} \approx 1.047938$  
$cp_2^y = 0.900000 - \frac{0.897786 - 0.900000}{6} \approx 0.900369$ 

$cp_1^y = 0.070464 + \frac{0.036057 - 0.588875}{6} \approx -0.021672$  
$cp_2^y = 0.036057 - \frac{0.551626 - 0.070464}{6} \approx -0.044137$  

I've checked youtube just to make sure if i didn't mess something up, and we basically have a match with what's inside of youtube's SVG:

<sub>uosc:</sub>
<img width="1920" height="46" alt="uosc" src="https://github.com/user-attachments/assets/3bc2d9fa-4360-425d-92e8-98618dadf779" />
<sub>youtube site display:</sub>
<img width="1920" height="40" alt="youtube" src="https://github.com/user-attachments/assets/d7213c1d-28ab-427e-89cf-9ccbd987c39c" />
<sub>youtube full SVG:</sub>
![youtubefullsvg](https://github.com/user-attachments/assets/d5eb6273-bc95-4966-96c9-517cd8fd8357)

From what i can tell, youtube draws the heatmap by filling rectangles with color and using an SVG `clip-path` to mask the visible area, which slices the peaks that extend beyond their 40px tall clipping region, so this is expected behaviour.

Seems like we're going to need that `\clip` to keep everything tidy without distorting the heatmap.

Should i open a seperate PR for this, or should i simply add it to this commit to avoid polluting the history too much ?


<sub> Also fixed that stray space indentation while i'm at it :^) </sub>