### PR TITLE
fix: unset cache_underrun when demuxer-cache-state becomes unavailable

### DIFF
--- a/src/uosc/main.lua
+++ b/src/uosc/main.lua
@@ -745,6 +745,7 @@ mp.observe_property('demuxer-cache-state', 'native', function(prop, cache_state)
 		set_state('cache_duration', not cache_state.eof and cache_state['cache-duration'] or nil)
 	else
 		cached_ranges = {}
+		set_state('cache_underrun', false)
 	end
 
 	if not (state.duration and (#cached_ranges > 0 or state.cache == 'yes' or


### PR DESCRIPTION
If --idle and --force-window is used and playback of a buffering file is aborted, the buffering indicator will remain enabled until a new file is loaded because of this not being unset.