### PR TITLE
Make pause_indicator opacity configurable

### DIFF
--- a/src/uosc.conf
+++ b/src/uosc.conf
@@ -158,7 +158,7 @@ border_radius=4
 color=
 # A comma delimited list of opacity overrides for various UI element backgrounds and shapes.
 # This does not affect any text, which is always rendered fully opaque. Defaults:
-# timeline=0.9,position=1,chapters=0.8,slider=0.9,slider_gauge=1,controls=0,speed=0.6,menu=1,submenu=0.4,border=1,title=1,tooltip=1,thumbnail=1,curtain=0.8,idle_indicator=0.8,audio_indicator=0.5,buffering_indicator=0.3,playlist_position=0.8,heatmap=0.4
+# timeline=0.9,position=1,chapters=0.8,slider=0.9,slider_gauge=1,controls=0,speed=0.6,menu=1,submenu=0.4,border=1,title=1,tooltip=1,thumbnail=1,curtain=0.8,idle_indicator=0.8,audio_indicator=0.5,buffering_indicator=0.3,playlist_position=0.8,heatmap=0.4,pause_indicator=0.8
 opacity=
 # A comma delimited list of features to refine at a cost of some performance impact.
 # text_width - Use a more accurate text width measurement that measures each text string individually

--- a/src/uosc/elements/PauseIndicator.lua
+++ b/src/uosc/elements/PauseIndicator.lua
@@ -14,7 +14,7 @@ function PauseIndicator:init()
 end
 
 function PauseIndicator:init_options()
-	self.base_icon_opacity = options.pause_indicator == 'flash' and 1 or 0.8
+	self.base_icon_opacity = config.opacity.pause_indicator or (options.pause_indicator == 'flash' and 1) or 0.8
 	self.type = options.pause_indicator
 	self:on_prop_pause()
 end


### PR DESCRIPTION
Just a small patch I've been using to make the opacity of the pause indicator configurable, particularly when using pause_indicator=static - otherwise it doesn't really matter that much I suppose.

### Testing
* set pause_indicator=static (it isn't that visible with flash)
* set opacity=pause_indicator=0.2 - or some other clearly visible value
* Verify opacity is different by pausing a playing video
* remove the opacity=pause_indicator option
* verify opacity is back to normal (0.8)