### PR TITLE
feat: center speed indicator by improving layout algorithm

### DIFF
--- a/src/uosc/elements/Controls.lua
+++ b/src/uosc/elements/Controls.lua
@@ -377,15 +377,65 @@ function Controls:update_dimensions()
 	local width_for_dynamics = available_width - statics_width
 	local empty_space_width = width_for_dynamics - max_dynamics_width
 	local width_for_gaps = math.min(empty_space_width, size * gaps)
-	local individual_space_width = spaces > 0 and ((empty_space_width - width_for_gaps) / spaces) or 0
 
+	-- Calculate per-space widths: if exactly 2 spaces, center content between them absolutely
+	local space_widths = {}
+	if spaces == 2 then
+		-- Measure content width in each section: before space1, between spaces, after space2
+		local section = 1
+		local section_widths = {0, 0, 0}
+		for c, control in ipairs(self.layout) do
+			if not control.hide then
+				if control.sizing == 'space' then
+					section = section + 1
+				else
+					local w = 0
+					if control.sizing == 'gap' then
+						if width_for_gaps > 0 then w = width_for_gaps * (control.ratio / gaps) end
+					elseif control.sizing == 'static' then
+						w = size * control.scale * control.ratio + (c ~= #self.layout and spacing or 0)
+					elseif control.sizing == 'dynamic' then
+						local height = size * control.scale
+						w = (max_dynamics_width < width_for_dynamics
+							and height * control.ratio or width_for_dynamics * ((control.scale * control.ratio) / dynamic_units))
+							+ (c ~= #self.layout and spacing or 0)
+					end
+					section_widths[section] = section_widths[section] + w
+				end
+			end
+		end
+		local left_w, middle_w = section_widths[1], section_widths[2]
+		local total_space = empty_space_width - width_for_gaps
+		-- For absolute centering: space1 + left_w + middle_w/2 = available_width/2
+		local space1 = (available_width - middle_w) / 2 - left_w
+		local space2 = total_space - space1
+		-- Clamp: both spaces must be non-negative. If one side would go negative,
+		-- transfer the deficit to the other side so space1 + space2 == total_space
+		-- is preserved whenever that's still possible (i.e. total_space >= 0).
+		if space1 < 0 then
+			space2 = space2 + space1
+			space1 = 0
+		elseif space2 < 0 then
+			space1 = space1 + space2
+			space2 = 0
+		end
+		if space1 < 0 then space1 = 0 end
+		if space2 < 0 then space2 = 0 end
+		space_widths = {space1, space2}
+	else
+		local individual_space_width = spaces > 0 and ((empty_space_width - width_for_gaps) / spaces) or 0
+		for i = 1, spaces do space_widths[i] = individual_space_width end
+	end
+
+	local space_index = 0
 	for c, control in ipairs(self.layout) do
 		if not control.hide then
 			local sizing, element, scale, ratio = control.sizing, control.element, control.scale, control.ratio
 			local width, height = 0, 0
 
 			if sizing == 'space' then
-				if individual_space_width > 0 then width = individual_space_width end
+				space_index = space_index + 1
+				width = space_widths[space_index] or 0
 			elseif sizing == 'gap' then
 				if width_for_gaps > 0 then width = width_for_gaps * (ratio / gaps) end
 			elseif sizing == 'static' then

--- a/src/uosc/elements/Controls.lua
+++ b/src/uosc/elements/Controls.lua
@@ -406,14 +406,8 @@ function Controls:update_dimensions()
 		end
 		local left_w, middle_w = section_widths[1], section_widths[2]
 		local total_space = empty_space_width - width_for_gaps
-		-- middle_w's last control (if not the very last item in self.layout) has a
-		-- trailing `spacing` baked into its width by the loop above, but that gap sits
-		-- between the control and space2 in the actual layout pass below — it isn't
-		-- part of the control's own visual footprint. Strip it so the centering math
-		-- centers the control itself, not the control-plus-trailing-gap.
-		local adjusted_middle_w = middle_w > spacing and (middle_w - spacing) or middle_w
-		-- For absolute centering: space1 + left_w + adjusted_middle_w/2 = available_width/2
-		local space1 = (available_width - adjusted_middle_w) / 2 - left_w
+		-- For absolute centering: space1 + left_w + middle_w/2 = available_width/2
+		local space1 = (available_width - middle_w) / 2 - left_w + spacing / 2
 		local space2 = total_space - space1
 		-- Clamp: both spaces must be non-negative. If one side would go negative,
 		-- transfer the deficit to the other side so space1 + space2 == total_space

--- a/src/uosc/elements/Controls.lua
+++ b/src/uosc/elements/Controls.lua
@@ -406,8 +406,14 @@ function Controls:update_dimensions()
 		end
 		local left_w, middle_w = section_widths[1], section_widths[2]
 		local total_space = empty_space_width - width_for_gaps
-		-- For absolute centering: space1 + left_w + middle_w/2 = available_width/2
-		local space1 = (available_width - middle_w) / 2 - left_w
+		-- middle_w's last control (if not the very last item in self.layout) has a
+		-- trailing `spacing` baked into its width by the loop above, but that gap sits
+		-- between the control and space2 in the actual layout pass below — it isn't
+		-- part of the control's own visual footprint. Strip it so the centering math
+		-- centers the control itself, not the control-plus-trailing-gap.
+		local adjusted_middle_w = middle_w > spacing and (middle_w - spacing) or middle_w
+		-- For absolute centering: space1 + left_w + adjusted_middle_w/2 = available_width/2
+		local space1 = (available_width - adjusted_middle_w) / 2 - left_w
 		local space2 = total_space - space1
 		-- Clamp: both spaces must be non-negative. If one side would go negative,
 		-- transfer the deficit to the other side so space1 + space2 == total_space


### PR DESCRIPTION
Before：
<img width="2559" height="1439" alt="屏幕截图 2026-07-30 085056" src="https://github.com/user-attachments/assets/3e62b297-9071-4dd2-b997-fcf8ec4e8096" />


now:
<img width="2559" height="1439" alt="屏幕截图 2026-07-30 084758" src="https://github.com/user-attachments/assets/ffe81e6e-8f03-49b3-a43e-c72a3b1f757b" />

<img width="1021" height="599" alt="屏幕截图 2026-07-30 085423" src="https://github.com/user-attachments/assets/a49c7b20-861d-4c7a-bef7-f4bfa6d52719" />

No visual regressions observed when shrinking the window.

<img width="600" height="521" alt="屏幕截图 2026-07-30 090106" src="https://github.com/user-attachments/assets/8d12e032-3f5e-4620-be08-d7eca6eb430a" />


