### PR TITLE
Adjust the conditions for changes in the 'has_many_editions' attribute

### DIFF
--- a/src/uosc/main.lua
+++ b/src/uosc/main.lua
@@ -696,7 +696,7 @@ mp.observe_property('track-list', 'native', function(name, value)
 	Elements:trigger('dispositions')
 end)
 mp.observe_property('editions', 'number', function(_, editions)
-	if editions then set_state('has_many_edition', editions > 1) end
+	set_state('has_many_edition', editions and editions > 1)
 	Elements:trigger('dispositions')
 end)
 mp.observe_property('chapter-list', 'native', function(_, chapters)


### PR DESCRIPTION
Fix: Ensure `has_many_edition` state updates correctly when switching to files without editions

Previously, the `editions` property observer had a conditional check:
`if editions then ...`. When switching from a file with editions to one without,
the `editions` property becomes `nil`. Because of the `if` condition, the
`set_state('has_many_edition', editions > 1)` line never executed, leaving the
state stuck at `true`.

After removing the condition, correctly returns `false` when
`editions` is `nil`, properly hiding the editions button.